### PR TITLE
Syntax: Don't highlight fields

### DIFF
--- a/syntax/yagpdbcc/main.vim
+++ b/syntax/yagpdbcc/main.vim
@@ -86,8 +86,18 @@ syntax match yagpdbccDot "\v%(\{\{|\s)\."ms=e
     " Order is key here. If you do the dot later, it takes priority over the
     " generic field and top-level object syntaxes, breaking them.
 syntax match yagpdbccObject "\v[\$\)]@<!>@<!\.[[:alnum:]\_]+"
-    " We use \zs here to start the match region, because we can't use a
-    " constant offset from either end to do so.
+    " Regex Explanation:
+    " - [\$\)]@<!  Negative lookbehind for the character class given (literal
+    "   dollar sign or closing parenthesis). Any expression that directly
+    "   follows these, even if it starts with a dot, is not a top-level
+    "   object.
+    " - >@<!  Negative lookbehind for the right edge of a word (i.e.
+    "   end-of-word). Any expression directly following one of these is a
+    "   second-level (or deeper) field of an object, which we don't highlight.
+    " - \.[[:alnum:]\_]+  Normal match expression, searching for a dot
+    "   followed by one or more alphanumeric characters or an underscore. This
+    "   is the actual text of the object -- e.g. `.User` (an object provided
+    "   by the YAGPDB custom command system).
 highlight default link yagpdbccDot Type
 highlight default link yagpdbccType Type
 highlight default link yagpdbccObject Type

--- a/syntax/yagpdbcc/main.vim
+++ b/syntax/yagpdbcc/main.vim
@@ -85,14 +85,12 @@ highlight default link yagpdbccKeyword Keyword
 syntax match yagpdbccDot "\v%(\{\{|\s)\."ms=e
     " Order is key here. If you do the dot later, it takes priority over the
     " generic field and top-level object syntaxes, breaking them.
-syntax match yagpdbccObject "\v>@!\.[[:alnum:]\_]+" nextgroup=yagpdbccField
-syntax match yagpdbccField "\v>\)?\zs\.[[:alnum:]\_]+" nextgroup=yagpdbccField
+syntax match yagpdbccObject "\v[\$\)]@<!>@<!\.[[:alnum:]\_]+"
     " We use \zs here to start the match region, because we can't use a
     " constant offset from either end to do so.
 highlight default link yagpdbccDot Type
 highlight default link yagpdbccType Type
 highlight default link yagpdbccObject Type
-highlight default link yagpdbccField Type
 
 " Special
 syntax match yagpdbccEscaped "\v\\[nt\"\\]" contained


### PR DESCRIPTION
**Please describe the changes this pull request does and why it should be merged:**

Fields are annoying, because there's no way to know what kind of object they really are (short of implementing full type checking, which is not feasible in a little extension like this). For example, in `$myVar.myField`, `myField` could be a normal field or a dictionary key.

We feel it's safer not to highlight than to highlight as any particular data type and risk giving false information. Also, we don't want to make the whole screen a mass of random colors -- leaving some text un-highlighted is a good thing.

**Terms**
- [X] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
