### PR TITLE
Feature: Yank buffer to system clipboard

### DIFF
--- a/ftplugin/yagpdbcc/functions.vim
+++ b/ftplugin/yagpdbcc/functions.vim
@@ -43,11 +43,21 @@ function! s:NextSection(type, backwards, visual)
     execute 'silent normal! ' . dir . pattern . dir . flags . "\r"
 endfunction
 
-noremap <script> <buffer> <silent> ]] :call <SID>NextSection(1, 0, 0)<cr>
-noremap <script> <buffer> <silent> [[ :call <SID>NextSection(1, 1, 0)<cr>
-noremap <script> <buffer> <silent> ][ :call <SID>NextSection(2, 0, 0)<cr>
-noremap <script> <buffer> <silent> [] :call <SID>NextSection(2, 1, 0)<cr>
+noremap  <script> <buffer> <silent> ]] :call      <SID>NextSection(1, 0, 0)<cr>
+noremap  <script> <buffer> <silent> [[ :call      <SID>NextSection(1, 1, 0)<cr>
+noremap  <script> <buffer> <silent> ][ :call      <SID>NextSection(2, 0, 0)<cr>
+noremap  <script> <buffer> <silent> [] :call      <SID>NextSection(2, 1, 0)<cr>
 vnoremap <script> <buffer> <silent> ]] :<c-u>call <SID>NextSection(1, 0, 1)<cr>
 vnoremap <script> <buffer> <silent> [[ :<c-u>call <SID>NextSection(1, 1, 1)<cr>
 vnoremap <script> <buffer> <silent> ][ :<c-u>call <SID>NextSection(2, 0, 1)<cr>
 vnoremap <script> <buffer> <silent> [] :<c-u>call <SID>NextSection(2, 1, 1)<cr>
+
+" Quick function and command to copy the whole file to the system clipboard
+function! YagCopy()
+    if has('clipboard')
+        execute '%y *'
+    else
+        echo "Your vim doesn't appear to have clipboard support."
+    endif
+endfunction
+command! YagCopy :call YagCopy()


### PR DESCRIPTION
**Please describe the changes this pull request does and why it should be merged:**

Adds a command to quickly copy the entire buffer to the system clipboard, via the `"*` register.

Further details discussed in #6. Closes #6.

**Terms**
- [X] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
