### PR TITLE
ftdetect: use line continuation and autocmd groups

### DIFF
--- a/ftdetect/yagpdbcc.vim
+++ b/ftdetect/yagpdbcc.vim
@@ -18,6 +18,10 @@
 " 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 " commonly used extesions are: .go.tmpl .gotmpl .yag .yagpdb .yagcc .yagpdbcc
-autocmd BufNewFile,BufRead *.go.tmpl,*.gotmpl setfiletype yagpdbcc
-autocmd BufNewFile,BufRead *.yag,*.yagpdb,*.yagcc setfiletype yagpdbcc
-autocmd BufNewFile,BufRead *.yag-cc,*.yagpdbcc,*.yagpdb-cc setfiletype yagpdbcc
+augroup yagpdbcc_set_ft
+    autocmd!
+    autocmd BufNewFile,BufRead
+                \ *.go.tmpl,*.gotmpl,*.yag,*.yagpdb,
+                \*.yagcc,*.yag-cc,*.yagpdbcc,*.yagpdb-cc
+                \ setfiletype yagpdbcc
+augroup end


### PR DESCRIPTION
**Please describe the changes this pull request does and why it should be merged:**

This PR reformats the filetype detection script to adhere to autocommand best practices (namely, using autocommand groups that are cleared every time they're sourced, to avoid duplicate autocommand definitions), and uses line continuation as opposed to multiple autocommands.
This change could probably have been pushed directly to master, but there's no harm in PRing either.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
