### PR TITLE
ci: set up vint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,22 @@
+# GitHub workflow configuration file: Continuous Integration
+#
+# Copyright (C) 2021    Lucas Ritzdorf, Luca Zeuch
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+
 ---
 name: CI
 
@@ -13,9 +32,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  # Run Unit Tests via vader.vim
   test:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout repository
         uses: actions/checkout/@v2
@@ -24,3 +43,24 @@ jobs:
           sudo apt install vim
       - name: Run tests
         run: make test
+
+  # Vim script linting
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+      - name: Install vim-vint
+        run: |
+          python -m pip install --upgrade pip
+          pip install vim-vint
+      - name: Install Vim
+        run: |
+          sudo apt install vim
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: run linter
+        run: |
+          python scripts/vint.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install vim-vint
-      - name: Install Vim
-        run: |
-          sudo apt install vim
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: run linter

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,10 +48,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 3.6
       - name: Install vim-vint
         run: |
           python -m pip install --upgrade pip

--- a/.vintrc.yml
+++ b/.vintrc.yml
@@ -1,0 +1,29 @@
+# Vim Lint Configuration file.
+#
+# Copyright (C) 2021    Lucas Ritzdorf, Luca Zeuch
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Be strict
+cmdargs:
+ severity: style_problem
+
+policies:
+  ProhibitNoAbortFunction:
+    enabled: false
+  ProhibitImplicitScopeVariable:
+    enabled: true
+  ProhibitUnusedVariable:
+    enabled: true

--- a/scripts/vint.py
+++ b/scripts/vint.py
@@ -67,29 +67,31 @@ def process_output(output):
     try:
         issues = json.loads(output)
 
-        for issue in issues:
-            print(generate_github_output(issue))
+        generate_github_output(issues)
 
     except AttributeError:
         print("Failed loading JSON...")
     except ValueError:
         print("Failed loading JSON...")
 
-def generate_github_output(issue):
-    level = issue.get('severity')
-    message = f"{issue.get('description')}. See {issue.get('reference')}."
-    path = issue.get('file_path')
-    line = issue.get('line_number')
-    column = issue.get('column_number')
+def generate_github_output(issues):
+    for issue in issues:
+        level = issue.get('severity')
+        message = f"{issue.get('description')}. See {issue.get('reference')}."
+        path = issue.get('file_path')
+        line = issue.get('line_number')
+        column = issue.get('column_number')
 
+        if level == "error":
+            print(f"::error file={path},line={line},col={column}::{message}")
 
-    if level == ("error"):
-        return f"::error file={path},line={line},col={column}::{message}"
+        if level == "warning":
+            print(f"::warning file={path},line={line},col={column}::{message}")
 
-    if level == ("warning"):
-        return f"::warning file={path},line={line},col={column}::{message}"
+        if level == "style_problem":
+            print(f"::notice file={path},line={line},col={column}::{message}")
 
-    if level == ("style_problem"):
-        return f"::notice file={path},line={line},col={column}::{message}"
+    if issues != None:
+        sys.exit(1)
 
 compile()

--- a/scripts/vint.py
+++ b/scripts/vint.py
@@ -1,0 +1,95 @@
+# Script to convert Vint's Linter warnings to valid GitHub warning or error
+#
+# Copyright (C) 2021    Lucas Ritzdorf, Luca Zeuch
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+import json
+import shutil
+import subprocess
+import sys
+
+# Generate our vint command and fail if the executable is not found.
+def generate_command():
+    exe = shutil.which("vint")
+    args = [
+        exe,
+        "--json",
+        "."
+        ]
+
+    if exe == None:
+        print("No vint executable found. Install it with pip install vim-vint.")
+        sys.exit(1)
+
+    return ' '.join(args)
+
+# Run our generated command and give back our output.
+def exec():
+    command = generate_command()
+    print("--- COMMAND: ", command)
+
+    try:
+        process = subprocess.Popen(command, stdout = subprocess.PIPE, shell=True)
+        output = process.stdout.read()
+        process.wait()
+
+        return output
+
+    except subprocess.CalledProcessError as e:
+        print("Error in calling Vint: ", e.output)
+        return None
+    except:
+        print("Unexpected error:", sys.exc_info()[0])
+        return None
+
+def compile():
+    output = exec()
+
+    if output == None:
+        print("No violations found.")
+        sys.exit(0)
+
+    process_output(output)
+
+def process_output(output):
+    try:
+        issues = json.loads(output)
+
+        for issue in issues:
+            print(generate_github_output(issue))
+
+    except AttributeError:
+        print("Failed loading JSON...")
+    except ValueError:
+        print("Failed loading JSON...")
+
+def generate_github_output(issue):
+    level = issue.get('severity')
+    message = f"{issue.get('description')}. See {issue.get('reference')}."
+    path = issue.get('file_path')
+    line = issue.get('line_number')
+    column = issue.get('column_number')
+
+
+    if level == ("error"):
+        return f"::error file={path},line={line},col={column}::{message}"
+
+    if level == ("warning"):
+        return f"::warning file={path},line={line},col={column}::{message}"
+
+    if level == ("style_problem"):
+        return f"::notice file={path},line={line},col={column}::{message}"
+
+compile()

--- a/scripts/vint.py
+++ b/scripts/vint.py
@@ -28,7 +28,7 @@ def generate_command():
         print("No vint executable found. Install it with pip install vim-vint.")
         sys.exit(1)
 
-    return f"{exe} --json ."
+    return [exe, "--json", "."]
 
 def generate_github_output(issues):
     # Map Vint's levels to GitHub's message levels.
@@ -56,7 +56,7 @@ def get_vint_output():
     print("--- COMMAND: ", command)
 
     try:
-        process = subprocess.Popen(command, stdout = subprocess.PIPE, shell=True)
+        process = subprocess.Popen(command, stdout = subprocess.PIPE)
         output = process.stdout.read()
         process.wait()
 

--- a/scripts/vint.py
+++ b/scripts/vint.py
@@ -75,6 +75,8 @@ def process_output(output):
         print("Failed loading JSON...")
 
 def generate_github_output(issues):
+    fail =  False
+
     for issue in issues:
         level = issue.get('severity')
         message = f"{issue.get('description')}. See {issue.get('reference')}."
@@ -84,14 +86,16 @@ def generate_github_output(issues):
 
         if level == "error":
             print(f"::error file={path},line={line},col={column}::{message}")
+            fail = True
 
         if level == "warning":
             print(f"::warning file={path},line={line},col={column}::{message}")
+            fail = True
 
         if level == "style_problem":
             print(f"::notice file={path},line={line},col={column}::{message}")
 
-    if issues != None:
+    if fail:
         sys.exit(1)
 
 compile()


### PR DESCRIPTION
As discussed, project maintainers agreed on setting up a linting tool
for the Vim script programming language. This commit adds said tool with
a configured GitHub workflow as well as a basic configuration file.

It currently is expected behaviour that the workflow fails, as there are some errors thrown by the linter. 
This does not inhibit mergeability of this pull request and is merely a result of the linter's rather strict configuration.

Let me know what you think, whether it is too strict or not -- Documentation can be found at [Vimjas/vint](https://github.com/Vimjas/vint/wiki).

Closes #16

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
