### PR TITLE
Satisfy vint style checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Syntax highlighting for [YAGPDB](https://yagpdb.xyz) custom commands in (N)Vim.
 
+[![CI](https://github.com/l-zeuch/yagpdb.vim/actions/workflows/ci.yml/badge.svg)](https://github.com/l-zeuch/yagpdb.vim/actions/workflows/ci.yml)
+
 ## Installing
 
 Use your favorite plugin manager to install this plugin. [tpope/vim-pathogen](https://github.com/tpope/vim-pathogen), [VundleVim/Vundle.vim](https://github.com/VundleVim/Vundle.vim), [junegunn/vim-plug](https://github.com/junegunn/vim-plug), and [Shougo/dein.vim](https://github.com/Shougo/dein.vim) are some of the more popular ones. A lengthy discussion of these and other managers can be found on [vi.stackexchange.com](https://vi.stackexchange.com/questions/388/what-is-the-difference-between-the-vim-plugin-managers). Basic instructions are provided below, but please **be sure to read, understand, and follow all the safety rules that come with your ~~power tools~~ plugin manager.**

--- a/ftplugin/yagpdbcc/functions.vim
+++ b/ftplugin/yagpdbcc/functions.vim
@@ -27,20 +27,20 @@ function! s:NextSection(type, backwards, visual)
     endif
 
     if a:type == 1
-        let pattern = '\v%(\n\n^\S|%^)'
-        let flags = 'e'
+        let l:pattern = '\v%(\n\n^\S|%^)'
+        let l:flags = 'e'
     elseif a:type == 2
-        let pattern = '\v%(\n\n^\S|%$)'
-        let flags = ''
+        let l:pattern = '\v%(\n\n^\S|%$)'
+        let l:flags = ''
     endif
 
     if a:backwards
-        let dir = '?'
+        let l:dir = '?'
     else
-        let dir = '/'
+        let l:dir = '/'
     endif
 
-    execute 'silent normal! ' . dir . pattern . dir . flags . "\r"
+    execute 'silent normal! ' . l:dir . l:pattern . l:dir . l:flags . '\r'
 endfunction
 
 noremap  <script> <buffer> <silent> ]] :call      <SID>NextSection(1, 0, 0)<cr>

--- a/ftplugin/yagpdbcc/functions.vim
+++ b/ftplugin/yagpdbcc/functions.vim
@@ -21,7 +21,13 @@ inoremap         {{  {{}}<left><left>
 inoremap <expr>  }}  strpart(getline('.'), col('.')-1, 2) == "}}" ? "\<right>\<right>" : "}}"
 
 " Make jumping between sections work nicely
+" TODO: This sequence of two vint commands shouldn't be necessary, but their
+" "next-line" syntax is broken. We'll update this when the PyPI version of
+" vint is updated to include their fix. The proper line is:
+" " vint: next-line -ProhibitUnusedVariable
+" vint: -ProhibitUnusedVariable
 function! s:NextSection(type, backwards, visual)
+" vint: +ProhibitUnusedVariable
     if a:visual
         normal! gv
     endif

--- a/syntax/yagpdbcc/main.vim
+++ b/syntax/yagpdbcc/main.vim
@@ -22,7 +22,7 @@
 "   LRitzdorf <42657792+LRitzdorf@users.noreply.github.com>
 
 " Quit when a (custom) syntax file was already loaded
-if exists("b:current_syntax")
+if exists('b:current_syntax')
     finish
 endif
 
@@ -136,4 +136,4 @@ syntax match yagpdbccTodo "\v<%(TODO|FIXME|HACK|XXX)>" contained
 highlight default link yagpdbccTodo Todo
 
 
-let b:current_syntax = "yagpdbcc"
+let b:current_syntax = 'yagpdbcc'


### PR DESCRIPTION
**Please describe the changes this pull request does and why it should be merged:**

This PR makes some minor changes to style in relevant Vimscript files, so that the recently-merged (#17) CI linting step passes cleanly.

Note that vint has a [bug](https://github.com/Vimjas/vint/issues/329) where their `next-line` syntax isn't recognized, so for now, we work around this by disabling the relevant check for one line, then reenabling it.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
