### PR TITLE
tests: improve feedback of tests

### DIFF
--- a/test/clipboard.vader
+++ b/test/clipboard.vader
@@ -41,9 +41,6 @@ Given (example yagpdbcc code):
     {{ end }}
   {{ end }}
 
-Execute:
-  Log "Test clipboard"
-
 Do (run YagCopy):
   :YagCopy\<Enter>
   "+p

--- a/test/clipboard.vader
+++ b/test/clipboard.vader
@@ -41,6 +41,9 @@ Given (example yagpdbcc code):
     {{ end }}
   {{ end }}
 
+Execute:
+  Log "Test clipboard"
+
 Do (run YagCopy):
   :YagCopy\<Enter>
   "+p

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -55,45 +55,38 @@ Given (code with comments):
 
 Execute (syntax check):
 # Opening brace
-  Log "Testing comment region (opening brace)"
-  AssertEqual 'yagpdbccComment', SyntaxAt(1, 1)
+  AssertEqual 'yagpdbccComment', SyntaxAt(1, 1), "Match comment region opening brace"
 
 # Closing brace and following line
-  Log "Testing comment region (last match and closing brace)"
-  AssertEqual 'yagpdbccComment', SyntaxAt(1, 37)
-  AssertEqual '', SyntaxAt(2, 1)
+  AssertEqual 'yagpdbccComment', SyntaxAt(1, 37), "Comment region last match"
+  AssertEqual '', SyntaxAt(2, 1), "Comment region actually ends"
 
 # Ensure text inside and after the extra braces is still a comment
-  Log "Testing comment region (inside)"
-  AssertEqual 'yagpdbccComment', SyntaxAt(3, 19)
-  AssertEqual 'yagpdbccComment', SyntaxAt(3, 32)
+  AssertEqual 'yagpdbccComment', SyntaxAt(3, 19), "Comment region continues inside"
+  AssertEqual 'yagpdbccComment', SyntaxAt(3, 32), "Comment region continues inside"
 
 # TODOs and FIXMEs, but only inside comments
-  Log "Testing comment region (TODO / FIXME)"
-  AssertEqual 'yagpdbccTodo', SyntaxAt(4, 6)
-  AssertEqual 'yagpdbccComment', SyntaxAt(4, 12)
-  AssertEqual '', SyntaxAt(5, 1)
-  AssertEqual 'yagpdbccTodo', SyntaxAt(6, 6)
-  AssertEqual 'yagpdbccComment', SyntaxAt(6, 13)
+  AssertEqual 'yagpdbccTodo', SyntaxAt(4, 6), "Match TODO inside comments"
+  AssertEqual 'yagpdbccComment', SyntaxAt(4, 12), "Don't expand TODO match too far"
+  AssertEqual '', SyntaxAt(5, 1), "Don't match TODO outside of comment"
+  AssertEqual 'yagpdbccTodo', SyntaxAt(6, 6), "Match FIXME inside comment"
+  AssertEqual 'yagpdbccComment', SyntaxAt(6, 13), "Don't expand FIXME match too far"
 
 # a plain text area
-  Log "Testing plain text"
-  AssertEqual '', SyntaxAt(7, 1)
+  AssertEqual '', SyntaxAt(7, 1), "Match plain text area with no syntax"
 
 # Multiline comments
-  Log "Testing multiline comments"
-  AssertEqual 'yagpdbccComment', SyntaxAt(7, 13)
-  AssertEqual 'yagpdbccComment', SyntaxAt(8, 1)
-  AssertEqual 'yagpdbccComment', SyntaxAt(10, 1)
-  AssertEqual 'yagpdbccComment', SyntaxAt(11, 2)
-  AssertEqual 'yagpdbccComment', SyntaxAt(11, 5)
+  AssertEqual 'yagpdbccComment', SyntaxAt(7, 13), "Match multiline comment 1/5"
+  AssertEqual 'yagpdbccComment', SyntaxAt(8, 1), "Match multiline comment 2/5"
+  AssertEqual 'yagpdbccComment', SyntaxAt(10, 1), "Match multiline comment 3/5"
+  AssertEqual 'yagpdbccComment', SyntaxAt(11, 2), "Match multiline comment 4/5"
+  AssertEqual 'yagpdbccComment', SyntaxAt(11, 5), "Match multiline comment 5/5"
 
 # Don't match the invalid embedded comment syntax
-  Log "Testing invalid embedded comment syntax"
-  AssertEqual 'yagpdbccExpr', SyntaxAt(12, 58)
+  AssertEqual 'yagpdbccExpr', SyntaxAt(12, 58), "Don't match invalid embedded comment"
 
 Given (normal code sample):
-  {{ $args := parseArgs 0 "Please run this command with a user (mention or ID), or without any arguemnts (in which case it will run on you)."
+  {{ $args := parseArgs 0 "Please run this command with a user (mention or ID), or without any arguments (in which case it will run on you)."
       (carg "userid" "User to analyze") }}
   {{ $member := 0 }} {{ $user := 0 }} range 5 "asdf" {{/* Comments, woo! */}}
   {{ if $args.Get 0 }}
@@ -109,75 +102,60 @@ Given (normal code sample):
 
 Execute (syntax check):
 # Validate syntax elements in the first and second lines
-  Log "Validate identifier match"
-  AssertEqual 'yagpdbccIdentifier', SyntaxAt(1, 4)
-  Log "Validate operator match"
-  AssertEqual 'yagpdbccOperator', SyntaxAt(1, 10)
-  Log "Validate matching inbuilt function"
-  AssertEqual 'yagpdbccFunction', SyntaxAt(1, 13)
-  Log "Valide number match"
-  AssertEqual 'yagpdbccNumber', SyntaxAt(1, 23)
-  Log "Validate string match"
-  AssertEqual 'yagpdbccString', SyntaxAt(1, 27)
-  Log "Validate inbuild function with line continuation"
-  AssertEqual 'yagpdbccFunction', SyntaxAt(2, 6)
+  AssertEqual 'yagpdbccIdentifier', SyntaxAt(1, 4), "Match identifier"
+  AssertEqual 'yagpdbccOperator', SyntaxAt(1, 10), "Match operator"
+  AssertEqual 'yagpdbccFunction', SyntaxAt(1, 13), "Match inbuilt function name"
+  AssertEqual 'yagpdbccNumber', SyntaxAt(1, 23), "Match number"
+  AssertEqual 'yagpdbccString', SyntaxAt(1, 27), "Match string"
+  AssertEqual 'yagpdbccFunction', SyntaxAt(2, 6), "Match inbuilt function name w/ line continuation inside braces"
 
 # Validate the third line, with its non-standard format
-  Log "Validate matching multiple actions on single line"
-  AssertEqual 'yagpdbccIdentifier', SyntaxAt(3, 4)
-  AssertEqual '', SyntaxAt(3, 19)
-  AssertEqual '', SyntaxAt(3, 37)
-  AssertEqual '', SyntaxAt(3, 43)
-  AssertEqual '', SyntaxAt(3, 45)
-  AssertEqual 'yagpdbccComment', SyntaxAt(3, 57)
+  AssertEqual 'yagpdbccIdentifier', SyntaxAt(3, 4), "Match identifer inside braces"
+  AssertEqual '', SyntaxAt(3, 19), "Don't match characters after closing brace"
+  AssertEqual '', SyntaxAt(3, 37), "Don't match syntax keywords outside braces"
+  AssertEqual '', SyntaxAt(3, 43), "Don't match numbers outside braces"
+  AssertEqual '', SyntaxAt(3, 45), "Don't match strings outside braces"
+  AssertEqual 'yagpdbccComment', SyntaxAt(3, 57), "Match comments inside braces"
 
 # Strings
-  Log "Test string delimiters"
-  AssertEqual 'yagpdbccString', SyntaxAt(2, 11)
-  AssertEqual 'yagpdbccString', SyntaxAt(2, 20)
-  AssertEqual '', SyntaxAt(2, 39)
+  AssertEqual 'yagpdbccString', SyntaxAt(2, 11), "Match string delimiter start w/ line continuation inside braces"
+  AssertEqual 'yagpdbccString', SyntaxAt(2, 20), "Match string content w/ line continuation inside braces"
+  AssertEqual '', SyntaxAt(2, 39), "Don't expand string match too far"
 
 # Check the new syntax elements in the following lines (no need to re-check
 # variable matching, for example - that's already been validated)
 # ifs and elses are part of the conditional group
-  Log "Test conditional verb match"
-  AssertEqual 'yagpdbccConditional', SyntaxAt(4, 4)
+  AssertEqual 'yagpdbccConditional', SyntaxAt(4, 4), "Match conditional keyword inside braces"
 
 # The .Get method on line 5 isn't matched, so it's just part of a basic
 # expression region
-  Log "Validate no match on .Get method"
-  AssertEqual 'yagpdbccFunction', SyntaxAt(5, 16)
-  AssertEqual 'yagpdbccExpr', SyntaxAt(5, 30)
-  AssertEqual 'yagpdbccFunction', SyntaxAt(6, 18)
-  AssertEqual 'yagpdbccConditional', SyntaxAt(7, 4)
-  AssertEqual 'yagpdbccOperator', SyntaxAt(8, 14)
+  AssertEqual 'yagpdbccFunction', SyntaxAt(5, 16), "Match inbuilt function name"
+  AssertEqual 'yagpdbccExpr', SyntaxAt(5, 30), "Don't match methods"
+  AssertEqual 'yagpdbccFunction', SyntaxAt(6, 18), "Match inbuilt function name"
+  AssertEqual 'yagpdbccConditional', SyntaxAt(7, 4), "Match conditional keyword"
+  AssertEqual 'yagpdbccOperator', SyntaxAt(8, 14), "Match operator"
 
 # Objects, like .User and .Member, are matched as types
-  Log "Validate object match as type"
-  AssertEqual 'yagpdbccObject', SyntaxAt(8, 16)
-  AssertEqual 'yagpdbccObject', SyntaxAt(9, 18)
+  AssertEqual 'yagpdbccObject', SyntaxAt(8, 16), "Match level-1 object"
+  AssertEqual 'yagpdbccObject', SyntaxAt(9, 18), "Match level-1 object"
 
 # end is just a general keyword
-  Log "Validate keyword \'end\' match"
-  AssertEqual 'yagpdbccKeyword', SyntaxAt(10, 4)
+  AssertEqual 'yagpdbccKeyword', SyntaxAt(10, 4), "Match `end` keyword"
 
 # Single character constants
-  Log "Validate single character constant match"
-  AssertEqual 'yagpdbccCharacter', SyntaxAt(11, 21)
-  AssertEqual 'yagpdbccCharacter', SyntaxAt(11, 22)
-  AssertEqual '', SyntaxAt(11, 26)
+  AssertEqual 'yagpdbccCharacter', SyntaxAt(11, 21), "Match single character constant"
+  AssertEqual 'yagpdbccCharacter', SyntaxAt(11, 22), "Match single character constant end delimiter"
+  AssertEqual '', SyntaxAt(11, 26), "Don't expand character match too far"
 
 # Escape character constant
-  Log "Validate escape character sequence in single character constant"
-  AssertEqual 'yagpdbccCharacter', SyntaxAt(12, 21)
-  AssertEqual 'yagpdbccCharacter', SyntaxAt(12, 23)
-  AssertEqual '', SyntaxAt(12, 27)
+  AssertEqual 'yagpdbccCharacter', SyntaxAt(12, 21), "Match first character of escape sequence in character constant"
+  AssertEqual 'yagpdbccCharacter', SyntaxAt(12, 23), "Match character constant end delimiter"
+  AssertEqual '', SyntaxAt(12, 27), "Don't expand character match too far"
 
 # This will be fun, '"' is really weird.
-  Log "Validate that \'\"\' still matches because that's really weird"
-  AssertEqual 'yagpdbccCharacter', SyntaxAt(13, 21)
-  AssertEqual 'yagpdbccCharacter', SyntaxAt(13, 22)
-  AssertEqual '', SyntaxAt(13, 26)
+  AssertEqual 'yagpdbccCharacter', SyntaxAt(13, 21), "Match \" inside character constants"
+  AssertEqual 'yagpdbccCharacter', SyntaxAt(13, 22), "Match character string delimiter"
+  AssertEqual '', SyntaxAt(13, 26), "Don't expand match too far"
 
 
 Given (code with errors):
@@ -189,31 +167,26 @@ Given (code with errors):
 
 Execute (syntax check):
 # The classic beginner syntax mistake
-  Log "Validate error on nested braces"
-  AssertEqual 'yagpdbccNestedBraces', SyntaxAt(1, 46)
-  AssertEqual '', SyntaxAt(1, 66)
+  AssertEqual 'yagpdbccNestedBraces', SyntaxAt(1, 46), "Match error on nested braces"
+  AssertEqual '', SyntaxAt(1, 66), "Don't expand error match too far"
 
 # Invalid Variable naming
-  Log "Validate error on invalid identifier"
-  AssertEqual 'yagpdbccError', SyntaxAt(2, 43)
-  AssertEqual '', SyntaxAt(2, 65)
+  AssertEqual 'yagpdbccError', SyntaxAt(2, 43), "Match error on invalid identifier"
+  AssertEqual '', SyntaxAt(2, 65), "Don't expand error too far"
 
 # Weird, but valid edge case
-  Log "Validate that {{\"{{\"}} does not throw error"
-  AssertEqual 'yagpdbccString', SyntaxAt(3, 9)
-  AssertEqual '', SyntaxAt(3, 22)
+  AssertEqual 'yagpdbccString', SyntaxAt(3, 9), "Don't match \"{{\" as error"
+  AssertEqual '', SyntaxAt(3, 22), "Don't expand string match too far"
 
 # Invalid character constant
-  Log "Validate error on too long character constant"
-  AssertEqual 'yagpdbccCharacterError', SyntaxAt(4, 22)
-  AssertEqual 'yagpdbccCharacterError', SyntaxAt(4, 23)
-  AssertEqual '', SyntaxAt(4, 31)
+  AssertEqual 'yagpdbccCharacterError', SyntaxAt(4, 22), "Match error for multiple character constants"
+  AssertEqual 'yagpdbccCharacterError', SyntaxAt(4, 23), "Match end delimiter as error as well"
+  AssertEqual '', SyntaxAt(4, 31), "Don't expand error too far"
 
 # Strange character constant edge case (just why)
-  Log "Validate error on \'\n something\'"
-  AssertEqual 'yagpdbccCharacterError', SyntaxAt(5, 21)
-  AssertEqual 'yagpdbccCharacterError', SyntaxAt(4, 27)
-  AssertEqual '', SyntaxAt(4, 31)
+  AssertEqual 'yagpdbccCharacterError', SyntaxAt(5, 21), "Match error on things like \'\n something\'"
+  AssertEqual 'yagpdbccCharacterError', SyntaxAt(4, 27), "Match end delimiter as error as well"
+  AssertEqual '', SyntaxAt(4, 31), "Don't expand error too far"
 
 Given (a variety of syntax elements):
   Even with weird variables, {{ print "like " $.Name }}, and the empty variable!
@@ -233,7 +206,6 @@ Given (a variety of syntax elements):
 Execute (syntax check):
 # TODO (just pass for now)
 # Don't forget to check time functions and printf formatting
-  Log "Pass for now..."
   AssertEqual 1, 1
 
 Given (custom embed with lots of nested syntax elements):
@@ -253,6 +225,5 @@ Given (custom embed with lots of nested syntax elements):
 
 Execute (syntax check):
 # TODO (just pass for now)
-  Log "Pass for now..."
   AssertEqual 1, 1
 

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -55,17 +55,21 @@ Given (code with comments):
 
 Execute (syntax check):
 # Opening brace
+  Log "Testing comment region (opening brace)"
   AssertEqual 'yagpdbccComment', SyntaxAt(1, 1)
 
 # Closing brace and following line
+  Log "Testing comment region (last match and closing brace)"
   AssertEqual 'yagpdbccComment', SyntaxAt(1, 37)
   AssertEqual '', SyntaxAt(2, 1)
 
 # Ensure text inside and after the extra braces is still a comment
+  Log "Testing comment region (inside)"
   AssertEqual 'yagpdbccComment', SyntaxAt(3, 19)
   AssertEqual 'yagpdbccComment', SyntaxAt(3, 32)
 
 # TODOs and FIXMEs, but only inside comments
+  Log "Testing comment region (TODO / FIXME)"
   AssertEqual 'yagpdbccTodo', SyntaxAt(4, 6)
   AssertEqual 'yagpdbccComment', SyntaxAt(4, 12)
   AssertEqual '', SyntaxAt(5, 1)
@@ -73,9 +77,11 @@ Execute (syntax check):
   AssertEqual 'yagpdbccComment', SyntaxAt(6, 13)
 
 # a plain text area
+  Log "Testing plain text"
   AssertEqual '', SyntaxAt(7, 1)
 
 # Multiline comments
+  Log "Testing multiline comments"
   AssertEqual 'yagpdbccComment', SyntaxAt(7, 13)
   AssertEqual 'yagpdbccComment', SyntaxAt(8, 1)
   AssertEqual 'yagpdbccComment', SyntaxAt(10, 1)
@@ -83,6 +89,7 @@ Execute (syntax check):
   AssertEqual 'yagpdbccComment', SyntaxAt(11, 5)
 
 # Don't match the invalid embedded comment syntax
+  Log "Testing invalid embedded comment syntax"
   AssertEqual 'yagpdbccExpr', SyntaxAt(12, 58)
 
 Given (normal code sample):
@@ -102,14 +109,21 @@ Given (normal code sample):
 
 Execute (syntax check):
 # Validate syntax elements in the first and second lines
+  Log "Validate identifier match"
   AssertEqual 'yagpdbccIdentifier', SyntaxAt(1, 4)
+  Log "Validate operator match"
   AssertEqual 'yagpdbccOperator', SyntaxAt(1, 10)
+  Log "Validate matching inbuilt function"
   AssertEqual 'yagpdbccFunction', SyntaxAt(1, 13)
+  Log "Valide number match"
   AssertEqual 'yagpdbccNumber', SyntaxAt(1, 23)
+  Log "Validate string match"
   AssertEqual 'yagpdbccString', SyntaxAt(1, 27)
+  Log "Validate inbuild function with line continuation"
   AssertEqual 'yagpdbccFunction', SyntaxAt(2, 6)
 
 # Validate the third line, with its non-standard format
+  Log "Validate matching multiple actions on single line"
   AssertEqual 'yagpdbccIdentifier', SyntaxAt(3, 4)
   AssertEqual '', SyntaxAt(3, 19)
   AssertEqual '', SyntaxAt(3, 37)
@@ -118,6 +132,7 @@ Execute (syntax check):
   AssertEqual 'yagpdbccComment', SyntaxAt(3, 57)
 
 # Strings
+  Log "Test string delimiters"
   AssertEqual 'yagpdbccString', SyntaxAt(2, 11)
   AssertEqual 'yagpdbccString', SyntaxAt(2, 20)
   AssertEqual '', SyntaxAt(2, 39)
@@ -125,10 +140,12 @@ Execute (syntax check):
 # Check the new syntax elements in the following lines (no need to re-check
 # variable matching, for example - that's already been validated)
 # ifs and elses are part of the conditional group
+  Log "Test conditional verb match"
   AssertEqual 'yagpdbccConditional', SyntaxAt(4, 4)
 
 # The .Get method on line 5 isn't matched, so it's just part of a basic
 # expression region
+  Log "Validate no match on .Get method"
   AssertEqual 'yagpdbccFunction', SyntaxAt(5, 16)
   AssertEqual 'yagpdbccExpr', SyntaxAt(5, 30)
   AssertEqual 'yagpdbccFunction', SyntaxAt(6, 18)
@@ -136,23 +153,28 @@ Execute (syntax check):
   AssertEqual 'yagpdbccOperator', SyntaxAt(8, 14)
 
 # Objects, like .User and .Member, are matched as types
+  Log "Validate object match as type"
   AssertEqual 'yagpdbccObject', SyntaxAt(8, 16)
   AssertEqual 'yagpdbccObject', SyntaxAt(9, 18)
 
 # end is just a general keyword
+  Log "Validate keyword \'end\' match"
   AssertEqual 'yagpdbccKeyword', SyntaxAt(10, 4)
 
 # Single character constants
+  Log "Validate single character constant match"
   AssertEqual 'yagpdbccCharacter', SyntaxAt(11, 21)
   AssertEqual 'yagpdbccCharacter', SyntaxAt(11, 22)
   AssertEqual '', SyntaxAt(11, 26)
 
 # Escape character constant
+  Log "Validate escape character sequence in single character constant"
   AssertEqual 'yagpdbccCharacter', SyntaxAt(12, 21)
   AssertEqual 'yagpdbccCharacter', SyntaxAt(12, 23)
   AssertEqual '', SyntaxAt(12, 27)
 
 # This will be fun, '"' is really weird.
+  Log "Validate that \'\"\' still matches because that's really weird"
   AssertEqual 'yagpdbccCharacter', SyntaxAt(13, 21)
   AssertEqual 'yagpdbccCharacter', SyntaxAt(13, 22)
   AssertEqual '', SyntaxAt(13, 26)
@@ -167,23 +189,28 @@ Given (code with errors):
 
 Execute (syntax check):
 # The classic beginner syntax mistake
+  Log "Validate error on nested braces"
   AssertEqual 'yagpdbccNestedBraces', SyntaxAt(1, 46)
   AssertEqual '', SyntaxAt(1, 66)
 
 # Invalid Variable naming
+  Log "Validate error on invalid identifier"
   AssertEqual 'yagpdbccError', SyntaxAt(2, 43)
   AssertEqual '', SyntaxAt(2, 65)
 
 # Weird, but valid edge case
+  Log "Validate that {{\"{{\"}} does not throw error"
   AssertEqual 'yagpdbccString', SyntaxAt(3, 9)
   AssertEqual '', SyntaxAt(3, 22)
 
 # Invalid character constant
+  Log "Validate error on too long character constant"
   AssertEqual 'yagpdbccCharacterError', SyntaxAt(4, 22)
   AssertEqual 'yagpdbccCharacterError', SyntaxAt(4, 23)
   AssertEqual '', SyntaxAt(4, 31)
 
 # Strange character constant edge case (just why)
+  Log "Validate error on \'\n something\'"
   AssertEqual 'yagpdbccCharacterError', SyntaxAt(5, 21)
   AssertEqual 'yagpdbccCharacterError', SyntaxAt(4, 27)
   AssertEqual '', SyntaxAt(4, 31)
@@ -206,6 +233,7 @@ Given (a variety of syntax elements):
 Execute (syntax check):
 # TODO (just pass for now)
 # Don't forget to check time functions and printf formatting
+  Log "Pass for now..."
   AssertEqual 1, 1
 
 Given (custom embed with lots of nested syntax elements):
@@ -225,5 +253,6 @@ Given (custom embed with lots of nested syntax elements):
 
 Execute (syntax check):
 # TODO (just pass for now)
+  Log "Pass for now..."
   AssertEqual 1, 1
 


### PR DESCRIPTION
Though still not perfect (i.e., no reporting *what*) failed, this is a
better approach than not telling at all what is being tested. Future
PRs/commits will improve on this commit to improve feedback provided to
developers.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
