### PR TITLE
completion: only load when nvim-cmp is available

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -25,11 +25,8 @@ on:
       - 'syntax/'
       - 'scripts/boilerplate.lua'
       - 'scripts/gen_code_completion.py'
-  pull_request:
-    paths:
-      - 'syntax/'
-      - 'scripts/boilerplate.lua'
-      - 'scripts/gen_code_completion.py'
+    branches:
+      - 'master'
 
 jobs:
   generate:

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -39,6 +39,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Regenerate completion Sources
         run: make generate
+      - name: Setup git
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
       - name: Commit regenerated files
         run: |
           if [[ -n "$(git status -s lua/)" ]]; then

--- a/lua/yagpdbcc.lua
+++ b/lua/yagpdbcc.lua
@@ -240,4 +240,7 @@ function source:execute(completion_item, callback)
 end
 
 ---Register custom source to nvim-cmp.
-require('cmp').register_source('yagpdb-cc', source.new())
+local hascmp, cmp = pcall(require, 'cmp')
+if hascmp then
+    cmp.register_source('yagpdb-cc', source.new())
+end

--- a/plugin/yagpdb.lua
+++ b/plugin/yagpdb.lua
@@ -1,20 +1,3 @@
 -- Load completion sources.
--- This file is not sourced when Neovim is unable to use Lua.
---
--- Copyright (C) 2021    Lucas Ritzdorf, Luca Zeuch
---
--- This program is free software; you can redistribute it and/or modify
--- it under the terms of the GNU General Public License as published by
--- the Free Software Foundation; either version 2 of the License, or
--- (at your option) any later version.
---
--- This program is distributed in the hope that it will be useful,
--- but WITHOUT ANY WARRANTY; without even the implied warranty of
--- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
--- GNU General Public License for more details.
---
--- You should have received a copy of the GNU General Public License along
--- with this program; if not, write to the Free Software Foundation, Inc.,
--- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-
+-- This file is not sourced when your editor is unable to use Lua.
 require('yagpdbcc')

--- a/scripts/boilerplate.lua
+++ b/scripts/boilerplate.lua
@@ -64,4 +64,6 @@ function source:execute(completion_item, callback)
 end
 
 ---Register custom source to nvim-cmp.
-require('cmp').register_source('yagpdb-cc', source.new())
+if (require('cmp')) then
+    require('cmp').register_source('yagpdb-cc', source.new())
+end

--- a/scripts/boilerplate.lua
+++ b/scripts/boilerplate.lua
@@ -64,6 +64,7 @@ function source:execute(completion_item, callback)
 end
 
 ---Register custom source to nvim-cmp.
-if (require('cmp')) then
-    require('cmp').register_source('yagpdb-cc', source.new())
+local hascmp, cmp = pcall(require, 'cmp')
+if hascmp then
+    cmp.register_source('yagpdb-cc', source.new())
 end


### PR DESCRIPTION
**Please describe the changes this pull request does and why it should be merged:**
This pull request fixes a bug introduced by the new completion feature, where we attempt to load a module that might not exist.
Now we simply check if it exists and then load our sources.

It also snips the unnecessary license header from the plugin file, as it is rather unnecessary (also that much boilerplate for a single line is rather silly and the license is implied already).

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
