### PR TITLE
build/test: refactor makefile

### DIFF
--- a/test/vimrc
+++ b/test/vimrc
@@ -1,4 +1,22 @@
-filetype off
+" Baseline vimrc for automated testing suite.
+" This file should not be edited when it isn't absolutely necessary.
+"
+" Copyright (C) 2021    Lucas Ritzdorf, Luca Zeuch
+"
+" This program is free software; you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation; either version 2 of the License, or
+" (at your option) any later version.
+"
+" This program is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+"
+" You should have received a copy of the GNU General Public License along
+" with this program; if not, write to the Free Software Foundation, Inc.,
+" 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
 set runtimepath+=../.bundle/vader.vim/
 set runtimepath+=../
 filetype plugin indent on


### PR DESCRIPTION
This commit modifies `Makefile` to be OS-agnostic as well as checking
for dependencies, such as python3, git, Neovim, and Vim.

This commit also adds the license header to the `test/vimrc` file, as it
was missing prior.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
