### PR TITLE
ci: fix generate workflow

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -22,7 +22,7 @@ name: Generate Sources
 on:
   push:
     paths:
-      - 'syntax/'
+      - 'syntax/**'
       - 'scripts/boilerplate.lua'
       - 'scripts/gen_code_completion.py'
     branches:
@@ -42,6 +42,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - name: Commit regenerated files
         run: |
+          git status
           if [[ -n "$(git status -s lua/)" ]]; then
             git commit lua/ -m "completion: regenerate sources"
             git push


### PR DESCRIPTION
workflows: correctly glob file paths

Previously, the file paths were not correctly globbed with
just ' syntax/' as pattern. This commit fixes this by adding the
"glob-star", letting us fully expand on that path.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
