### PR TITLE
workflows: use GH-CLI to checkout and push to PR

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,19 +30,19 @@ jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - name: checkout repository
+      - name: Checkout repository
         uses: actions/checkout@v2
-      - name: Setup Git
+      - name: Setup git
         run: |
           git config user.name github-actions
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - name: checkout PR
+      - name: Checkout PR
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh pr checkout ${{ github.event.pull_request.number }}
       - name: Generate Completion
         run: make generate
-      - name: Commit Changes
+      - name: Commit changes
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -20,32 +20,36 @@
 name: Generate Sources
 
 on:
-  push:
+  pull_request:
     paths:
       - 'syntax/**'
       - 'scripts/boilerplate.lua'
       - 'scripts/gen_code_completion.py'
-    branches:
-      - 'master'
 
 jobs:
   generate:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repository
+      - name: checkout repository
         uses: actions/checkout@v2
-      - name: Regenerate completion Sources
-        run: make generate
-      - name: Setup git
+      - name: Setup Git
         run: |
           git config user.name github-actions
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - name: Commit regenerated files
+      - name: checkout PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr checkout ${{ github.event.pull_request.number }}
+      - name: Generate Completion
+        run: make generate
+      - name: Commit Changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git status
           if [[ -n "$(git status -s lua/)" ]]; then
             git commit lua/ -m "completion: regenerate sources"
-            git push
-          else
-            echo "Nothing to commit."
           fi
+      - name: Push changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git push


### PR DESCRIPTION
This commit modifies the generate.yml workflow to use the pre-installed
GitHub CLI which comes on all GitHub-hosted runners. It is used to
properly checkout the pull request, which then allows us to actually
push automagic regeneration of completion sources.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
