### PR TITLE
refactor: optimise checks for global variables

### DIFF
--- a/ftdetect/yagpdbcc.vim
+++ b/ftdetect/yagpdbcc.vim
@@ -35,7 +35,7 @@ au BufRead,BufNewFile   *.yagpdbcc    setfiletype yagpdbcc
 au BufRead,BufNewFile   *.yagpdb-cc   setfiletype yagpdbcc
 
 " Also use *.tmpl, *.gotmpl et al., which are originally only Go.
-if exists('g:yagpdbcc_override_ft') && g:yagpdbcc_override_ft
+if get(g:, 'yagpdbcc_override_ft')
     au BufRead,BufNewFile   *.tmpl    setfiletype yagpdbcc
     au BufRead,BufNewFile   *.gotmpl  setfiletype yagpdbcc
 endif

--- a/ftplugin/yagpdbcc/functions.vim
+++ b/ftplugin/yagpdbcc/functions.vim
@@ -11,7 +11,6 @@
 " but WITHOUT ANY WARRANTY; without even the implied warranty of
 " MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 " GNU General Public License for more details.
-
 " You should have received a copy of the GNU General Public License along
 " with this program; if not, write to the Free Software Foundation, Inc.,
 " 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -61,7 +60,7 @@ vnoremap <script> <buffer> <silent> [] :<c-u>call <SID>NextSection(2, 1, 1)<cr>
 " Quick function and command to copy the whole file to the system clipboard
 function! YagCopy()
     if has('clipboard')
-        if exists('g:yagpdbcc_use_primary') && g:yagpdbcc_use_primary
+        if get(g:, 'yagpdbcc_use_primary')
             execute '%y *'
             " Fancy regex to remove the trailing newline that Vim copies
             let @*=substitute(@*,'\n$','','')

--- a/ftplugin/yagpdbcc/functions.vim
+++ b/ftplugin/yagpdbcc/functions.vim
@@ -11,6 +11,7 @@
 " but WITHOUT ANY WARRANTY; without even the implied warranty of
 " MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 " GNU General Public License for more details.
+
 " You should have received a copy of the GNU General Public License along
 " with this program; if not, write to the Free Software Foundation, Inc.,
 " 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.


### PR DESCRIPTION
This commit optimises the test for the documented global configuration
variables.
From `:h get()`:
get({list}, {idx}, [, {default}])
    Get item {idx} from {list}. When item is not available, return
    {default}. Return zero when {default} is omitted.

The benefit of this function is first and foremost readability, as it
only requires one clean call instead of chaining two things together.
Secondly, it is more intuitive to read, as well as easier to maintain.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>


**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
