### PR TITLE
build: refactor: add make install and help target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,5 +59,4 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: run linter
-        run: |
-          python scripts/vint.py
+        run: make lint

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,9 @@ VIM_PROG    := $(shell which vim)
 GIT_PROG    := $(shell which git)
 endif
 
+DATA_HOME := $(XDG_DATA_HOME)
+DATA_HOME ?= '~/.local/share'
+
 PHONY :=
 
 # ----------------------------------------------------------------------------
@@ -97,10 +100,10 @@ install:
 	@echo 'Installing plugin...'
 	@echo 'Looking for Neovim...'
 ifdef NVIM_PROG
-	@echo 'Found Neovim, installing to ~/.local/share/nvim/site/pack/l-zeuch/start/yagpdb.vim'
-	mkdir -p ~/.local/share/nvim/site/pack/l-zeuch/start/yagpdb.vim
+	@echo 'Found Neovim, installing to $(DATA_HOME)/nvim/site/pack/l-zeuch/start/yagpdb.vim'
+	mkdir -p $(DATA_HOME)/nvim/site/pack/l-zeuch/start/yagpdb.vim
 	git clone https://github.com/l-zeuch/yagpdb.vim.git \
-		~/.local/share/nvim/site/pack/l-zeuch/start/yagpdb.vim
+		$(DATA_HOME)/nvim/site/pack/l-zeuch/start/yagpdb.vim
 	@echo 'Done.'
 else ifdef VIM_PROG
 	@echo 'Falling back to Vim...'
@@ -135,7 +138,7 @@ PHONY += uninstall
 uninstall:
 	@echo 'Uninstalling plugin...'
 	-rm -rf ~/.vim/bundle/yagpb.vim
-	-rm -rf ~/.local/share/nvim/site/pack/l-zeuch/start/yagpdb.vim
+	-rm -rf $(DATA_HOME)/nvim/site/pack/l-zeuch/start/yagpdb.vim
 	@echo 'Done.'
 	@echo 'If you have added this to your runtimepath, remember to remove it again.'
 

--- a/Makefile
+++ b/Makefile
@@ -59,29 +59,29 @@ endif
 PHONY := help
 help:
 	@echo	'Cleaning:'
-	@echo	'	clean 		- Remove all dependencies located in `.bundle/`.'
-	@echo 	''
-	@echo 	'Development:'
-	@echo 	'	test 		- Run test suite for Neovim and Vim.'
-	@echo 	' 				  This target automatically skips Neovim and/or Vim'
-	@echo 	' 				  if the respective program is not found.'
-	@echo 	'	test-vim 	- Run test suite only for Vim.'
-	@echo 	' 	test-nvim 	- Run test suite only for Neovim.'
-	@echo 	''
-	@echo 	'Code Analysis:'
+	@echo	'	clean		- Remove all dependencies located in `.bundle/`.'
+	@echo	''
+	@echo	'Development:'
+	@echo	'	test		- Run test suite for Neovim and Vim.'
+	@echo	'				  This target automatically skips Neovim and/or Vim'
+	@echo	'				  if the respective program is not found.'
+	@echo	'	test-vim	- Run test suite only for Vim.'
+	@echo	'	test-nvim	- Run test suite only for Neovim.'
+	@echo	''
+	@echo	'Code Analysis:'
 	@echo	'	lint		- Run linter on Vim script codebase,'
-	@echo 	' 				  requires python3 and vim-vint module.'
-	@echo 	'	generate 	- Create completion sources for nvim-cmp.'
-	@echo 	' 				  Requires python3.'
-	@echo   ''
-	@echo 	'General:'
-	@echo 	'	all 		- Run everything: test, lint, generate.'
-	@echo 	' 	install 	- Install this plugin as a manually installed plugin.'
-	@echo 	' 				  Be careful, this target automagically prefers Neovim.'
-	@echo 	' 				  To force Vim, please use `install-vim`.'
+	@echo	'				  requires python3 and vim-vint module.'
+	@echo	'	generate	- Create completion sources for nvim-cmp.'
+	@echo	'				  Requires python3.'
+	@echo	''
+	@echo	'General:'
+	@echo	'	all		- Run everything: test, lint, generate.'
+	@echo	'	install		- Install this plugin as a manually installed plugin.'
+	@echo	'				  Be careful, this target automagically prefers Neovim.'
+	@echo	'				  To force Vim, please use `install-vim`.'
 	@echo	'	install-vim	- Same as above, but ONLY try for Vim.'
-	@echo 	' 	uninstall 	- Uninstall this plugin from both Neovim and Vim.'
-	@echo 	' 	help 		- Print this help message. This is the default.'
+	@echo	'	uninstall	- Uninstall this plugin from both Neovim and Vim.'
+	@echo	'	help		- Print this help message. This is the default.'
 
 PHONY += all
 all: test lint generate
@@ -155,7 +155,7 @@ test-vim: .bundle/vader.vim
 ifdef VIM_PROG
 	@echo Found Vim installation, running tests...
 	cd test/ && \
-	$(VIM_PROG) -EsNu vimrc --not-a-term -c 'Vader! * */*'
+		$(VIM_PROG) -EsNu vimrc --not-a-term -c 'Vader! * */*'
 else
 	@echo Vim not found, skipping tests...
 endif
@@ -165,7 +165,7 @@ test-nvim: .bundle/vader.vim
 ifdef NVIM_PROG
 	@echo Found Neovim installation, running tests...
 	cd test/ && \
-	$(NVIM_PROG) -EsNu vimrc --headless -c 'Vader! * */*'
+		$(NVIM_PROG) -EsNu vimrc --headless -c 'Vader! * */*'
 else
 	@echo Neovim not found, skipping tests...
 endif

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ VIM_PROG    := $(shell which vim)
 GIT_PROG    := $(shell which git)
 endif
 
+PHONY :=
+
 # ----------------------------------------------------------------------------
 #
 # General
@@ -56,7 +58,7 @@ endif
 # ----------------------------------------------------------------------------
 # If make is invoked without any target provided, this will be our default
 # target.
-PHONY := help
+PHONY += help
 help:
 	@echo	'Cleaning:'
 	@echo	'	clean		- Remove all dependencies located in `.bundle/`.'

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ Syntax highlighting for [YAGPDB](https://yagpdb.xyz) custom commands in (N)Vim.
 
 ## Installing
 
+### Manually
+
+To install without any external plugin-manager dependencies, simply download the `Makefile` and run `make install`.
+If you wish to install this for your Vim installation, but have Neovim installed as well, make sure to use the
+`install-vim` target.
+
+```shell
+$ wget https://raw.githubusercontent.com/l-zeuch/yagpdb.vim/master/Makefile && make install
+```
+
+See also as Greg Hurrell's excellent Youtube video: [Vim screencast #75: Plugin managers](https://www.youtube.com/watch?v=X2_R3uxDN6g).
+
+### With a Plugin Manager
+
 Use your favorite plugin manager to install this plugin. [tpope/vim-pathogen](https://github.com/tpope/vim-pathogen),
 [VundleVim/Vundle.vim](https://github.com/VundleVim/Vundle.vim), [junegunn/vim-plug](https://github.com/junegunn/vim-plug),
 and [Shougo/dein.vim](https://github.com/Shougo/dein.vim) are some of the more popular ones.
@@ -13,10 +27,6 @@ A lengthy discussion of these and other managers can be found on
 [vi.stackexchange.com](https://vi.stackexchange.com/questions/388/what-is-the-difference-between-the-vim-plugin-managers).
 Basic instructions are provided below, but please **be sure to read, understand, and follow all the safety rules that
 come with your ~~power tools~~ plugin manager.**
-
-If you have no favorite, or want to manage your plugins without 3rd-party dependencies, consider using Vim 8+ packages,
-as described in Greg Hurrell's excellent Youtube video:
-[Vim screencast #75: Plugin managers](https://www.youtube.com/watch?v=X2_R3uxDN6g).
 
 <details>
 <summary>Pathogen</summary>


### PR DESCRIPTION
This commit refactors the `Makefile` one more time, now adding section
documentation comments, as well as a help and install targets.

The install target has been documented in the README.md.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
