### PR TITLE
ftdetect: forcibly override existing `.tmpl` filetype

### DIFF
--- a/ftdetect/yagpdbcc.vim
+++ b/ftdetect/yagpdbcc.vim
@@ -36,6 +36,8 @@ au BufRead,BufNewFile   *.yagpdb-cc   setfiletype yagpdbcc
 
 " Also use *.tmpl, *.gotmpl et al., which are originally only Go.
 if get(g:, 'yagpdbcc_override_ft')
-    au BufRead,BufNewFile   *.tmpl    setfiletype yagpdbcc
+    " Here, we need to explicitly override the default "template" syntax for
+    " .tmpl files:
+    au BufRead,BufNewFile   *.tmpl    setlocal filetype=yagpdbcc
     au BufRead,BufNewFile   *.gotmpl  setfiletype yagpdbcc
 endif


### PR DESCRIPTION
**Please describe the changes this pull request does and why it should be merged:**

Previously, we used the `setfiletype` command, which will not override an existing filetype. This was an issue because Vim automatically assigns `.tmpl` files the `template` syntax, and this occurs before our plugin has a chance to tell it otherwise.

We now use `setlocal filetype=yagpdbcc`, which has no qualms about overriding things.

Fixes #33.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
