### PR TITLE
all: refactor codebase for autoload capabilities

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,16 +2,17 @@
 # Unless a later match is found, these two will be notified.
 *                       @l-zeuch @LRitzdorf
 
-# Base and tests
+# Base
 /ftdetect/              @LRitzdorf
 /ftplugin/              @LRitzdorf
-/test/                  @LRitzdorf
 /syntax/                @LRitzdorf
+/autoload/				@l-zeuch
+/plugin/                @l-zeuch
 
 # Code completion
 /lua/                   @l-zeuch
-/plugin/                @l-zeuch
 
 # Build and automation
+/test/                  @LRitzdorf
 /.github/workflows/     @l-zeuch
 /Makefile               @l-zeuch

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 /ftdetect/              @LRitzdorf
 /ftplugin/              @LRitzdorf
 /syntax/                @LRitzdorf
-/autoload/				@l-zeuch
+/autoload/              @l-zeuch
 /plugin/                @l-zeuch
 
 # Code completion

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,18 @@ jobs:
         uses: actions/checkout@v2
       - name: Install latest Vim stable
         uses: rhysd/action-setup-vim@v1
+        with:
+          version: v8.2.5046
       - name: Install latest Neovim
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
           version: v0.5.0
-      - name: Run Tests
-        run: make test
+      - name: Run Vim Tests
+        run: make test-vim
+      - name: Run Neovim Tests
+        if: always()
+        run: make test-nvim
 
 
   # Vim script linting

--- a/README.md
+++ b/README.md
@@ -104,9 +104,6 @@ detecting those extension as follows, if needed:
 let g:yagpdbcc_override_ft = 1
 ```
 
-Note that this particular bit of setup must come **before** the plugin is loaded (probably by your plugin manager),
-since `g:yagpdbcc_override_ft` is read only when the plugin first loads.
-
 ### Code Completion (Neovim >0.5 ONLY)
 
 We provide bundled sources for code-completion to be used with https://github.com/hrsh7th/nvim-cmp.

--- a/autoload/yagpdbcc.vim
+++ b/autoload/yagpdbcc.vim
@@ -1,7 +1,6 @@
-" File used to detect the filetype of extensions used for YAGPDB Custom
-" Commands.
+" Autoloading file for various bits of config and such.
 
-" Copyright (C) 2021    Lucas Ritzdorf, Luca Zeuch
+" Copyright (C) 2022    Lucas Ritzdorf, Luca Zeuch
 
 " This program is free software; you can redistribute it and/or modify
 " it under the terms of the GNU General Public License as published by
@@ -21,21 +20,13 @@
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
-" vint: -ProhibitAutocmdWithNoGroup
-" should not use augroups in ftdetect, see :help ftdetect
-"
-" [...] there is no "augroup" command, this has already been done when
-" sourcing your file. You could also use the pattern "*" and then check the
-" contents of the file to recognize it.
+function! yagpdbcc#OverrideFt() abort
+	return get(g:, 'yagpdbcc_override_ft')
+endfunction
 
-" Detect our 'own' extensions, which are usually used by a
-" vast majority of the userbase.
-au BufRead,BufNewFile   *.yag         setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagpdb      setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagcc       setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yag-cc      setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagpdbcc    setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagpdb-cc   setfiletype yagpdbcc
+function! yagpdbcc#UsePrimary() abort
+	return get(g:, 'yagpdbcc_use_primary')
+endfunction
 
 " Restore Vi compat
 let &cpoptions = s:cpo_save

--- a/autoload/yagpdbcc.vim
+++ b/autoload/yagpdbcc.vim
@@ -1,4 +1,4 @@
-" Autoloading file for various bits of config and such.
+" Autoloading file for the main plugin things.
 
 " Copyright (C) 2022    Lucas Ritzdorf, Luca Zeuch
 
@@ -20,13 +20,8 @@
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
-function! yagpdbcc#OverrideFt() abort
-	return get(g:, 'yagpdbcc_override_ft')
-endfunction
-
-function! yagpdbcc#UsePrimary() abort
-	return get(g:, 'yagpdbcc_use_primary')
-endfunction
+" This file will be populated with autoload-able global plugin functions.
+" Right now it is empty, because no such functions are needed yet.
 
 " Restore Vi compat
 let &cpoptions = s:cpo_save

--- a/autoload/yagpdbcc.vim
+++ b/autoload/yagpdbcc.vim
@@ -20,8 +20,23 @@
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
-" This file will be populated with autoload-able global plugin functions.
-" Right now it is empty, because no such functions are needed yet.
+" Quick function and command to copy the whole file to the system clipboard
+function! yagpdbcc#Copy()
+    if has('clipboard')
+        if yagpdbcc#config#UsePrimary() != 0
+            execute '%y *'
+            " Fancy regex to remove the trailing newline that Vim copies
+            let @*=substitute(@*,'\n$','','')
+        else
+            execute '%y +'
+            let @+=substitute(@+,'\n$','','')
+        endif
+    else
+        echohl Error
+        echo "Your Vim doesn't appear to have clipboard support."
+        echohl None
+    endif
+endfunction
 
 " Restore Vi compat
 let &cpoptions = s:cpo_save

--- a/autoload/yagpdbcc/config.vim
+++ b/autoload/yagpdbcc/config.vim
@@ -1,4 +1,4 @@
-" Main plugin file.
+" Autoloading file for various bits of config.
 
 " Copyright (C) 2022    Lucas Ritzdorf, Luca Zeuch
 
@@ -16,34 +16,19 @@
 " with this program; if not, write to the Free Software Foundation, Inc.,
 " 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-if exists('g:yagpdbcc_loaded')
-	finish
-endif
-let g:yagpdbcc_loaded = 1
-
 " Don't spam the user when Vim is started in Vi compat
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
-" vint: -ProhibitAutocmdWithNoGroup
-" Also use *.tmpl, *.gotmpl et al., which are originally only Go.
-if yagpdbcc#config#OverrideFt() != 0
-    " Here, we need to explicitly override the default "template" syntax for
-    " .tmpl files:
-    au BufRead,BufNewFile   *.tmpl    setlocal filetype=yagpdbcc
-    au BufRead,BufNewFile   *.gotmpl  setlocal filetype=yagpdbcc
-endif
-" vint: +ProhibitAutocmdWithNoGroup
+function! yagpdbcc#config#OverrideFt() abort
+	return get(g:, 'yagpdbcc_override_ft')
+endfunction
 
-" Load completion sources for nvim-cmp when Lua is supported.
-" This will also be the place for more Lua script, if we decide to add a few
-" more things that need/do Lua magic.
-if has('lua')
-lua << ENDLUA
-	require('yagpdbcc')
-ENDLUA
-endif
+function! yagpdbcc#config#UsePrimary() abort
+	return get(g:, 'yagpdbcc_use_primary')
+endfunction
 
 " Restore Vi compat
 let &cpoptions = s:cpo_save
 unlet s:cpo_save
+

--- a/ftdetect/yagpdbcc.vim
+++ b/ftdetect/yagpdbcc.vim
@@ -37,6 +37,12 @@ au BufRead,BufNewFile   *.yag-cc      setfiletype yagpdbcc
 au BufRead,BufNewFile   *.yagpdbcc    setfiletype yagpdbcc
 au BufRead,BufNewFile   *.yagpdb-cc   setfiletype yagpdbcc
 
+" Also use *.tmpl, *.gotmpl et al., which are originally only Go, if configured.
+" Here, we need to explicitly override the default syntax - "setfiletype"
+" will not override an existing filetype.
+au BufRead,BufNewFile   *.tmpl,*.gotmpl
+    \ if yagpdbcc#config#OverrideFt() | setlocal filetype=yagpdbcc | endif
+
 " Restore Vi compat
 let &cpoptions = s:cpo_save
 unlet s:cpo_save

--- a/ftplugin/yagpdbcc/folding.vim
+++ b/ftplugin/yagpdbcc/folding.vim
@@ -16,6 +16,14 @@
 " with this program; if not, write to the Free Software Foundation, Inc.,
 " 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+if exists('b:did_ftplugin')
+    finish
+endif
+
+" Don't spam the user when Vim is started in Vi compat
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
 setlocal commentstring="{{/* %s */}}"
 
 setlocal foldmethod=indent
@@ -25,3 +33,7 @@ setlocal foldignore=
     " The empty right side is correct here
 " For full folding support via `expr` mode, see
 " <https://learnvimscriptthehardway.stevelosh.com/chapters/49.html>
+
+" Restore Vi compat
+let &cpoptions = s:cpo_save
+unlet s:cpo_save

--- a/ftplugin/yagpdbcc/functions.vim
+++ b/ftplugin/yagpdbcc/functions.vim
@@ -16,6 +16,15 @@
 " with this program; if not, write to the Free Software Foundation, Inc.,
 " 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+if exists('b:did_ftplugin')
+    finish
+endif
+let b:did_ftplugin = 1
+
+" Don't spam the user when Vim is started in Vi compat
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
 " Automatically insert closing double braces
 inoremap         {{  {{}}<left><left>
 inoremap <expr>  }}  strpart(getline('.'), col('.')-1, 2) == "}}" ? "\<right>\<right>" : "}}"
@@ -61,7 +70,7 @@ vnoremap <script> <buffer> <silent> [] :<c-u>call <SID>NextSection(2, 1, 1)<cr>
 " Quick function and command to copy the whole file to the system clipboard
 function! YagCopy()
     if has('clipboard')
-        if get(g:, 'yagpdbcc_use_primary')
+        if yagpdbcc#UsePrimary() != 0
             execute '%y *'
             " Fancy regex to remove the trailing newline that Vim copies
             let @*=substitute(@*,'\n$','','')
@@ -70,7 +79,13 @@ function! YagCopy()
             let @+=substitute(@+,'\n$','','')
         endif
     else
-        echo "Your vim doesn't appear to have clipboard support."
+        echohl Error
+        echo "Your Vim doesn't appear to have clipboard support."
+        echohl None
     endif
 endfunction
 command! YagCopy :call YagCopy()
+
+" Restore Vi compat
+let &cpoptions = s:cpo_save
+unlet s:cpo_save

--- a/ftplugin/yagpdbcc/functions.vim
+++ b/ftplugin/yagpdbcc/functions.vim
@@ -70,7 +70,7 @@ vnoremap <script> <buffer> <silent> [] :<c-u>call <SID>NextSection(2, 1, 1)<cr>
 " Quick function and command to copy the whole file to the system clipboard
 function! YagCopy()
     if has('clipboard')
-        if yagpdbcc#UsePrimary() != 0
+        if yagpdbcc#config#UsePrimary() != 0
             execute '%y *'
             " Fancy regex to remove the trailing newline that Vim copies
             let @*=substitute(@*,'\n$','','')

--- a/ftplugin/yagpdbcc/functions.vim
+++ b/ftplugin/yagpdbcc/functions.vim
@@ -67,25 +67,6 @@ vnoremap <script> <buffer> <silent> [[ :<c-u>call <SID>NextSection(1, 1, 1)<cr>
 vnoremap <script> <buffer> <silent> ][ :<c-u>call <SID>NextSection(2, 0, 1)<cr>
 vnoremap <script> <buffer> <silent> [] :<c-u>call <SID>NextSection(2, 1, 1)<cr>
 
-" Quick function and command to copy the whole file to the system clipboard
-function! YagCopy()
-    if has('clipboard')
-        if yagpdbcc#config#UsePrimary() != 0
-            execute '%y *'
-            " Fancy regex to remove the trailing newline that Vim copies
-            let @*=substitute(@*,'\n$','','')
-        else
-            execute '%y +'
-            let @+=substitute(@+,'\n$','','')
-        endif
-    else
-        echohl Error
-        echo "Your Vim doesn't appear to have clipboard support."
-        echohl None
-    endif
-endfunction
-command! YagCopy :call YagCopy()
-
 " Restore Vi compat
 let &cpoptions = s:cpo_save
 unlet s:cpo_save

--- a/lua/yagpdbcc.lua
+++ b/lua/yagpdbcc.lua
@@ -45,6 +45,23 @@ end
 ---@param callback fun(response: lsp.CompletionResponse|nil)
 function source:complete(params, callback)
     callback({
+		{ label = 'if' },
+		{ label = 'else' },
+		{ label = 'with' },
+		{ label = 'try' },
+		{ label = 'catch' },
+		{ label = 'true' },
+		{ label = 'false' },
+		{ label = 'range' },
+		{ label = 'while' },
+		{ label = 'define' },
+		{ label = 'template' },
+		{ label = 'block' },
+		{ label = 'nil' },
+		{ label = 'end' },
+		{ label = 'return' },
+		{ label = 'break' },
+		{ label = 'continue' },
 		{ label = 'editChannelName' },
 		{ label = 'editChannelTopic' },
 		{ label = 'getChannel' },
@@ -208,24 +225,7 @@ function source:complete(params, callback)
 		{ label = 'currentUserCreated' },
 		{ label = 'pastNicknames' },
 		{ label = 'pastUsernames' },
-		{ label = 'userArg' },
-		{ label = 'if' },
-		{ label = 'else' },
-		{ label = 'with' },
-		{ label = 'try' },
-		{ label = 'catch' },
-		{ label = 'true' },
-		{ label = 'false' },
-		{ label = 'range' },
-		{ label = 'while' },
-		{ label = 'define' },
-		{ label = 'template' },
-		{ label = 'block' },
-		{ label = 'nil' },
-		{ label = 'end' },
-		{ label = 'return' },
-		{ label = 'break' },
-		{ label = 'continue' }
+		{ label = 'userArg' }
     })
 end
 

--- a/plugin/yagpdbcc.lua
+++ b/plugin/yagpdbcc.lua
@@ -1,3 +1,0 @@
--- Load completion sources.
--- This file is not sourced when your editor is unable to use Lua.
-require('yagpdbcc')

--- a/plugin/yagpdbcc.vim
+++ b/plugin/yagpdbcc.vim
@@ -44,6 +44,8 @@ lua << ENDLUA
 ENDLUA
 endif
 
+command! YagCopy :call yagpdbcc#Copy()
+
 " Restore Vi compat
 let &cpoptions = s:cpo_save
 unlet s:cpo_save

--- a/plugin/yagpdbcc.vim
+++ b/plugin/yagpdbcc.vim
@@ -28,10 +28,10 @@ set cpoptions&vim
 " vint: -ProhibitAutocmdWithNoGroup
 " Also use *.tmpl, *.gotmpl et al., which are originally only Go.
 if yagpdbcc#config#OverrideFt() != 0
-    " Here, we need to explicitly override the default "template" syntax for
-    " .tmpl files:
-    au BufRead,BufNewFile   *.tmpl    setlocal filetype=yagpdbcc
-    au BufRead,BufNewFile   *.gotmpl  setlocal filetype=yagpdbcc
+    " Here, we need to explicitly override the default syntax - "setfiletype"
+    " will not override an existing filetype.
+    au BufRead,BufNewFile *.tmpl,*.gotmpl
+        \ if yagpdbcc#config#OverrideFt() | setlocal filetype=yagpdbcc | endif
 endif
 " vint: +ProhibitAutocmdWithNoGroup
 

--- a/plugin/yagpdbcc.vim
+++ b/plugin/yagpdbcc.vim
@@ -25,16 +25,6 @@ let g:yagpdbcc_loaded = 1
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
-" vint: -ProhibitAutocmdWithNoGroup
-" Also use *.tmpl, *.gotmpl et al., which are originally only Go.
-if yagpdbcc#config#OverrideFt() != 0
-    " Here, we need to explicitly override the default syntax - "setfiletype"
-    " will not override an existing filetype.
-    au BufRead,BufNewFile *.tmpl,*.gotmpl
-        \ if yagpdbcc#config#OverrideFt() | setlocal filetype=yagpdbcc | endif
-endif
-" vint: +ProhibitAutocmdWithNoGroup
-
 " Load completion sources for nvim-cmp when Lua is supported.
 " This will also be the place for more Lua script, if we decide to add a few
 " more things that need/do Lua magic.

--- a/plugin/yagpdbcc.vim
+++ b/plugin/yagpdbcc.vim
@@ -1,7 +1,6 @@
-" File used to detect the filetype of extensions used for YAGPDB Custom
-" Commands.
+" Main plugin file.
 
-" Copyright (C) 2021    Lucas Ritzdorf, Luca Zeuch
+" Copyright (C) 2022    Lucas Ritzdorf, Luca Zeuch
 
 " This program is free software; you can redistribute it and/or modify
 " it under the terms of the GNU General Public License as published by
@@ -17,25 +16,33 @@
 " with this program; if not, write to the Free Software Foundation, Inc.,
 " 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
+if exists('g:yagpdbcc_loaded')
+	finish
+endif
+let g:yagpdbcc_loaded = 1
+
 " Don't spam the user when Vim is started in Vi compat
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
 " vint: -ProhibitAutocmdWithNoGroup
-" should not use augroups in ftdetect, see :help ftdetect
-"
-" [...] there is no "augroup" command, this has already been done when
-" sourcing your file. You could also use the pattern "*" and then check the
-" contents of the file to recognize it.
+" Also use *.tmpl, *.gotmpl et al., which are originally only Go.
+if yagpdbcc#OverrideFt() != 0
+    " Here, we need to explicitly override the default "template" syntax for
+    " .tmpl files:
+    au BufRead,BufNewFile   *.tmpl    setlocal filetype=yagpdbcc
+    au BufRead,BufNewFile   *.gotmpl  setlocal filetype=yagpdbcc
+endif
+" vint: +ProhibitAutocmdWithNoGroup
 
-" Detect our 'own' extensions, which are usually used by a
-" vast majority of the userbase.
-au BufRead,BufNewFile   *.yag         setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagpdb      setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagcc       setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yag-cc      setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagpdbcc    setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagpdb-cc   setfiletype yagpdbcc
+" Load completion sources for nvim-cmp when Lua is supported.
+" This will also be the place for more Lua script, if we decide to add a few
+" more things that need/do Lua magic.
+if has('lua')
+lua << ENDLUA
+	require('yagpdbcc')
+ENDLUA
+endif
 
 " Restore Vi compat
 let &cpoptions = s:cpo_save

--- a/syntax/yagpdbcc.vim
+++ b/syntax/yagpdbcc.vim
@@ -24,7 +24,9 @@
 if exists('b:current_syntax')
     finish
 endif
+let b:current_syntax = 'yagpdbcc'
 
+" Be case sensitive
 syn case match
 
 " Define the region of the template expressions, where the real code is.
@@ -94,7 +96,6 @@ hi def link     yagComment          Comment
 hi def link     yagTodo             Todo
 
 
-
 " Type
 " Order is key here. If we do this later, it takes precedence over the generic
 " field and top-level object syntaxes, breaking them.
@@ -116,5 +117,3 @@ syn match       yagObject           contained "\v%(>|[\$\)])@<!\.[[:alnum:]\_]+"
 hi def link     yagDot              yagType
 hi def link     yagObject           yagType
 hi def link     yagType             Type
-
-let b:current_syntax = 'yagpdbcc'


### PR DESCRIPTION
This commit touches up the whole codebase to add basic autoloading
capabilities to this plugin. It also replaces the plugin/yagpdbcc.lua
file with plugin/yagpdbcc.vim, for better compatibility reasons.

This allows us to manipulate both Vim and Neovim to our liking.
The override_ft functionality has been moved to the aforementioned new
file, in hopes that it will work better there; see the issue that the
config variable has to be set before loading, as per the README.

For *reasons*, the note will remain there until we can verify independly
that this is indeed an improvement over the current status quo.

Future work entails smaller refactor commits to make the overall
software more maintainable, as well as extensible, whenever appropriate.
We should also consider getting around managing folds properly, as of
now that capability still is missing.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
