### PR TITLE
plugin: fix loading of cmp items

### DIFF
--- a/plugin/yagpdbcc.vim
+++ b/plugin/yagpdbcc.vim
@@ -28,7 +28,7 @@ set cpoptions&vim
 " Load completion sources for nvim-cmp when Lua is supported.
 " This will also be the place for more Lua script, if we decide to add a few
 " more things that need/do Lua magic.
-if has('lua')
+if has('nvim-0.5')
 lua << ENDLUA
 	require('yagpdbcc')
 ENDLUA


### PR DESCRIPTION
The `has('lua')` call returns 0 for some reason. This commit modifies it
to test for nvim-0.5 *or higher*, so that it actually works.

Closes #50

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
