### PR TITLE
ftplugin: snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,16 +94,6 @@ used as follows:
 ```vim
 let g:yagpdbcc_use_primary = 1
 ```
-
-### Overriding Filetypes
-
-Sometimes, you may wish to use a file extension already in use by another language, such as `*.gotmpl`. Enable also
-detecting those extension as follows, if needed:
-
-```vim
-let g:yagpdbcc_override_ft = 1
-```
-
 ### Code Completion (Neovim >0.5 ONLY)
 
 We provide bundled sources for code-completion to be used with https://github.com/hrsh7th/nvim-cmp.
@@ -115,6 +105,27 @@ sources = cmp.config.sources({
     { name = 'yagpdb-cc' },
     ...
 })
+```
+
+### Overriding Filetypes
+
+Sometimes, you may wish to use a file extension already in use by another language, such as `*.gotmpl`. Enable also
+detecting those extension as follows, if needed:
+
+```vim
+let g:yagpdbcc_override_ft = 1
+```
+
+### Snippet Engines
+
+We provide snippets for two distinct engines: [UltiSnips](https://github.com/SirVer/ultisnips),
+and [Neosnippet](https://github.com/Shougo/neosnippet.vim).
+
+Select which one to use by setting the `g:yagpdbcc_snippet_engine` variable to either ` ultisnips`, or `neosnippet`,
+like so:
+
+```vim
+let g:yagpdbcc_snippet_engine = "ultisnips"
 ```
 
 ## Contributing

--- a/autoload/yagpdbcc/snippets.vim
+++ b/autoload/yagpdbcc/snippets.vim
@@ -1,0 +1,57 @@
+" File for snippet-logic related functions.
+
+" Copyright (C) 2021   Lucas Ritzdorf
+
+" This program is free software; you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation; either version 2 of the License, or
+" (at your option) any later version.
+
+" This program is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+
+" You should have received a copy of the GNU General Public License along
+" with this program; if not, write to the Free Software Foundation, Inc.,
+" 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+" don't spam the user when Vim is started in Vi compat
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
+function! yagpdbcc#snippets#UltiSnips() abort
+    if get(g:, 'did_plugin_ultisnip') isnot 1
+        return
+    endif
+
+    if !exists('g:UltiSnipsSnippetDirectories')
+        let g:UltiSnipsSnippetDirectories = ['snippets/UltiSnips']
+    else
+        let g:UltiSnipsSnippetDirectories += ['snippets/UltiSnips']
+    endif
+endfunction
+
+function! yagpdbcc#snippets#Neosnippet() abort
+    if get(g:, 'loaded_neosnippet') isnot 1
+        return
+    endif
+
+    let g:neosnippet#enable_snipmate_compatibility = 1
+
+    let l:yag_snip_dir = globpath(&runtimepath, 'snippets/neosnippet')
+    if type(g:neosnippet#snippets_directory) == type([])
+        let g:neosnippet#snippets_directory += [l:yag_snip_dir]
+    elseif type(g:neosnippet#snippets_directory) == type('')
+        if strlen(g:neosnippet#snippets_directory) > 0
+            let g:neosnippet#snippets_directory =
+                        \ g:neosnippet#snippets_directory . ',' . l:yag_snip_dir
+        endif
+    else
+        let g:neosnippet#snippets_directory = l:yag_snip_dir
+    endif
+endfunction
+
+" Restore Vi compat
+let &cpoptions = s:cpo_save
+unlet s:cpo_save

--- a/doc/yagpdbcc.txt
+++ b/doc/yagpdbcc.txt
@@ -130,20 +130,12 @@ plugins.
 ==============================================================================
 3. Configuration					     *yagpdbcc-config*
 
-CLIPBOARD
+CLIPBOARD						*g:yagpdbcc_use_primary*
 
 If you prefer to insert text with the middle mouse button instead of Ctrl V,
 change to the PRIMARY register as follows:
 >
     let g:yagpdbcc_use_primary = 1
-<
-OVERRIDING FILETYPES
-
-Sometimes, you may with to use a file extension already in use by another
-language, such as `*.gotmpl`. If that is the case, also select those
-extensions as follows:
->
-    let g:yagpdbcc_override_ft = 1
 <
 CODE COMPLETION
 
@@ -158,6 +150,24 @@ source as follows:
 	{ name = 'yagpdb-cc' },
 	-- ...
     })
+<
+OVERRIDING FILETYPES					*g:yagpdbcc_override_ft*
+
+Sometimes, you may with to use a file extension already in use by another
+language, such as `*.gotmpl`. If that is the case, also select those
+extensions as follows:
+>
+    let g:yagpdbcc_override_ft = 1
+<
+SNIPPET ENGINES					    *g:yagpdbcc_snippet_engine*
+
+We provide snippets for two distinct engines: SirVer/UltiSnips, and
+Shogo/neosnippet.vim.
+
+Select which one to use by setting the |g:yagpdbcc_snippet_engine| variable to
+either "ultisnips", or "neosnippet, like so:
+>
+    let g:yagpdbcc_snippet_engine = "ultisnips"
 <
 ==============================================================================
 4. Commands						   *yagpdbcc-commands*

--- a/ftplugin/yagpdbcc/snippets.vim
+++ b/ftplugin/yagpdbcc/snippets.vim
@@ -1,6 +1,7 @@
-" Autoloading file for various bits of config.
+" File to manage loading snippets, such as a basic custom command and other
+" more fancy stuff.
 
-" Copyright (C) 2022    Lucas Ritzdorf, Luca Zeuch
+" Copyright (C) 2021   Lucas Ritzdorf
 
 " This program is free software; you can redistribute it and/or modify
 " it under the terms of the GNU General Public License as published by
@@ -9,30 +10,29 @@
 
 " This program is distributed in the hope that it will be useful,
 " but WITHOUT ANY WARRANTY; without even the implied warranty of
-" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 " GNU General Public License for more details.
 
 " You should have received a copy of the GNU General Public License along
 " with this program; if not, write to the Free Software Foundation, Inc.,
 " 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-" Don't spam the user when Vim is started in Vi compat
+" don't spam the user when Vim is started in Vi compat
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
-function! yagpdbcc#config#OverrideFt() abort
-	return get(g:, 'yagpdbcc_override_ft')
-endfunction
+if exists('g:yagpdbcc_loaded_snippets')
+    finish
+endif
+let g:yagpdcc_loaded_snippets = 1
 
-function! yagpdbcc#config#UsePrimary() abort
-	return get(g:, 'yagpdbcc_use_primary')
-endfunction
-
-function! yagpdbcc#config#SnippetEngine() abort
-    return get(g:, 'yagpdbcc_snippet_engine')
-endfunction
+let s:engine = yagpdbcc#config#SnippetEngine()
+if s:engine is? 'ultisnips'
+    call yagpdbcc#snippets#Ultisnips()
+elseif s:engine is? 'neosnippet'
+    call yagdbcc#snippets#Neosnippet()
+endif
 
 " Restore Vi compat
 let &cpoptions = s:cpo_save
 unlet s:cpo_save
-

--- a/snippets/UltiSnips/yagpdbcc.snippets
+++ b/snippets/UltiSnips/yagpdbcc.snippets
@@ -1,0 +1,40 @@
+# UltiSnips snippets for YAGPDB custom commands.
+
+# Copyright (C) 2021   Luca Zeuch, Lucas Ritzdorf
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+priority -10
+
+snippet embed "cembed ..."
+$embed := cembed "description" "foo"
+endsnippet
+
+snippet fn "{{ define \"foo\"}}"
+{{ define "foo" }}
+    {{/* TODO: write function body */}}
+{{ end }}
+
+{{/* TODO: Change this */}}
+{{ template "foo" }}
+endsnippet
+
+snippet msgretid
+$silence := sendMessageRetID nil "foo"
+endsnippet
+
+snippet msgretidnoesc
+$silence = sendMessageNoEscapeRetID nil "foo"
+endsnippet

--- a/snippets/neosnippet/yagpdbcc.snip
+++ b/snippets/neosnippet/yagpdbcc.snip
@@ -1,0 +1,38 @@
+# Neosnippet snippets for YAGPDB custom commands.
+
+# Copyright (C) 2021   Luca Zeuch, Lucas Ritzdorf
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+snippet embed
+abbr $embed := cembed ...
+    $embed := cembed "description" "foo"
+
+snippet fn
+abbr {{ define "foo" }}
+    {{ define "foo" }}
+        {{/* TODO: write function body */}}
+    {{ end }}
+
+    {{/* TODO: Change this */}}
+    {{ template "foo" }}
+
+snippet msgretid
+abbr sendMessageRetID nil
+    $silence := sendMessageRetID nil "foo"
+
+snippet msgretidnoesc
+abbr sendMessageNoEscapeRetID nil
+    $silence := sendMessageNoEscapeRetID nil "foo"


### PR DESCRIPTION
This patchset adds the basic logic for connecting to a snippet backend, as well as some select snippets for two engines I've deemed worthwhile to support (as I've used both of them at some time already).

It also documents the newly added `g:yagpdbcc_snippet_engine` configuration variable.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
