### PR TITLE
ci: use a matrix strategy, sep jobs, add linters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,4 +27,4 @@ indent_size = 4
 indent_style = tab
 
 [*.md]
-max_line_length = 120
+max_line_length = 125

--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,8 @@
 lua/*           linguist-generated=true
 scripts/*.lua   linguist-generated=true
 
+# Not exactly our code
+.github/*.rb    linguist-vendored=true
+
 # Detect vader test files as Vim script
 *.vader         linguist-language=viml

--- a/.github/markdownlint.rb
+++ b/.github/markdownlint.rb
@@ -1,0 +1,16 @@
+# Markdownlint style configuration
+
+# Enable everything by default.
+all
+
+# Extend line length just a bit.
+rule 'MD013', :line_length => 125
+
+# Allow in-line HTML
+exclude_rule 'MD033'
+
+# Allow headers to end in punctuation
+exclude_rule 'MD026'
+
+# Allow bare URLs
+exclude_rule 'MD034'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # GitHub workflow configuration file: Continuous Integration
 #
-# Copyright (C) 2021    Lucas Ritzdorf, Luca Zeuch
+# Copyright (C) 2022    Lucas Ritzdorf, Luca Zeuch
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,37 +31,45 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Run Unit Tests via vader.vim
-  test:
+
+  test-vim:
     runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [v8.0.0000, v8.2.0000, v9.0.0000, stable]
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
       - name: Install latest Vim stable
         uses: rhysd/action-setup-vim@v1
         with:
-          version: v8.2.5046
+          version: ${{ matrix.version }}
+
+      - name: Run Vim Tests
+        run: make test-vim
+
+
+  test-nvim:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        version: [v0.5.0, v0.6.0, v0.7.0, stable]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Install latest Neovim
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true
-          version: v0.5.0
-      - name: Run Vim Tests
-        run: make test-vim
+          version: ${{ matrix.version }}
+
       - name: Run Neovim Tests
-        if: always()
         run: make test-nvim
-
-
-  # Vim script linting
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install vim-vint
-        run: |
-          python -m pip install --upgrade pip
-          pip install vim-vint
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: run linter
-        run: make lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -63,3 +63,5 @@ jobs:
 
       - name: Lint with Markdownlint
         uses: actionshub/markdownlint@main
+        with:
+          filesToIgnoreRegex: "LICENSE.*|permission\\.md"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# GitHub workflow configuration file: Completion source (re)generation
+# GitHub workflow configuration file: Linting
 #
 # Copyright (C) 2022    Lucas Ritzdorf, Luca Zeuch
 #
@@ -17,45 +17,49 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 ---
-name: Generate Sources
+name: Lint
 
 on:
+  push:
+    paths-ignore:
+      - '*.txt'
   pull_request:
-    paths:
-      - 'syntax/**'
-      - 'scripts/boilerplate.lua'
-      - 'scripts/gen_code_completion.py'
+    paths-ignore:
+      - '*.txt'
 
 jobs:
 
-  generate:
+  lint-vim:
     runs-on: ubuntu-latest
-
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GIT_USER: github-actions
-      GIT_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Setup git
+      - name: Install vim-vint
         run: |
-          git config user.name $GIT_USER
-          git config user.email $GIT_EMAIL
+          python -m pip install --upgrade pip
+          pip install vim-vint
 
-      - name: Checkout PR
-        run: gh pr checkout ${{ github.event.pull_request.number }}
+      - name: Run VimL linter
+        run: make lint
 
-      - name: Generate Completion
-        run: make generate
+  lint-python:
+    runs-on: ubuntu-latest
 
-      - name: Commit changes
-        run: |
-          if [[ -n "$(git status -s lua/)" ]]; then
-            git commit lua/ -m "completion: regenerate sources"
-          fi
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-      - name: Push changes
-        run: git push
+      - name: Lint with Pyright
+        uses: jakebailey/pyright-action@v1
+
+  lint-markdown:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Lint with Markdownlint
+        uses: actionshub/markdownlint@main

--- a/.mdlrc
+++ b/.mdlrc
@@ -1,0 +1,1 @@
+style '.github/markdownlint.rb'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contributing Guidelines
 
-Thank you for considering a contribution to the yagpdb-cc plugin for Vim. To get you started, here are a few guidelines we would like you to follow:
+Thank you for considering a contribution to the yagpdb-cc plugin for Vim. To get you started, here are a few guidelines
+we would like you to follow:
 
 * [Code of Conduct](#coc)
 * [Question or Problem?](#question)
@@ -9,23 +10,33 @@ Thank you for considering a contribution to the yagpdb-cc plugin for Vim. To get
 
 ## <a name="coc"></a> Code of Conduct
 
-By participating within this project and its repositories, you agree to abide by our [Code of Conduct](.github/CODE_OF_CONDUCT.md).
+By participating within this project and its repositories, you agree to abide by our
+[Code of Conduct](.github/CODE_OF_CONDUCT.md).
 
 ## <a name="question"></a> Got a Question?
 
-Please do not open issues for general support such as "how to install this plugin" as we want to keep this issue tracker for bug reports and feature requests. Instead, we suggest you use the search engine of your choice, as there are several good guides on how to install plugins - as a shortcut, we can recommend [pathogen](https://github.com/tpope/vim-pathogen).
+Please do not open issues for general support such as "how to install this plugin" as we want to keep this issue tracker
+for bug reports and feature requests. Instead, we suggest you use the search engine of your choice, as there are several
+good guides on how to install plugins.
 
-To save your and our  time, we will systematically close issues regarding general support. Issues regarding this repository (so-called "meta" issues) are excluded from this rule.
+As a shortcut, we can recommend [pathogen](https://github.com/tpope/vim-pathogen).
+
+To save your and our  time, we will systematically close issues regarding general support.
+Issues regarding this repository (so-called "meta" issues) are excluded from this rule.
 
 ## <a name="issue"></a> Found a Bug?
 
-If you find a bug in the code, you can help us by [submitting an issue](#submit-issue). Or, better, submit a [pull request](#submit-pr) with a fix readily available!
+If you find a bug in the code, you can help us by [submitting an issue](#submit-issue).
+Or, better, submit a [pull request](#submit-pr) with a fix readily available!
 
 ## <a name="feature"></a> Missing a feature?
 
-You can request a new feature by [submitting an issue](#submit-issue) to the issue tracker. If you would like to implement a new feature, please consider the impact it would have on the codebase:
+You can request a new feature by [submitting an issue](#submit-issue) to the issue tracker.
+If you would like to implement a new feature, please consider the impact it would have on the codebase:
 
-* For a major impact affecting multiple files, adding wholly new topics and sections to the documentation, etc., please open an issue first, outlining your proposal so that it can be discussed. This allows us to better coordinate our resources around your proposal and help you in crafting your contribution.
+* For a major impact affecting multiple files, adding wholly new topics and sections to the documentation, etc.:
+    please open an issue first, outlining your proposal so that it can be discussed.
+    This allows us to better coordinate our resources around your proposal and help you in crafting your contribution.
 
 * Small features can be put together and directly [submitted as a Pull Request](#submit-pr).
 
@@ -33,18 +44,22 @@ You can request a new feature by [submitting an issue](#submit-issue) to the iss
 
 ### <a name="submit-issue"></a> Submitting an Issue
 
-Before you submit a new issue, please search the issue tracker, maybe an issue relating to your problem already exists, and the discussion might inform you of fixes readily available.
+Before you submit a new issue, please search the issue tracker, maybe an issue relating to your problem already exists,
+and the discussion might inform you of fixes readily available.
 
 We want to fix all the issues as soon as possible, but before fixing a bug we need to reproduce and confirm it.
 In order to reproduce bugs, we require that you provide a minimal reproduction.
-Having a minimal reproducible scenario gives us a wealth of important information without going back and forth to you with additional questions.
+Having a minimal reproducible scenario gives us a wealth of important information without going back and forth to you
+with additional questions.
 
-A minimal reproduction allows us to quickly confirm a bug (or point out a coding problem) as well as confirm that we are fixing the right problem.
-Often, developers find coding problems themselves while preparing a minimal reproduction.
+A minimal reproduction allows us to quickly confirm a bug (or point out a coding problem) as well as confirm that we
+are fixing the right problem. Often, developers find coding problems themselves while preparing a minimal reproduction.
 
-Unfortunately, we are not able to investigate / fix bugs without a minimal reproduction, so if we don't hear back from you, we are going to close an issue that doesn't have enough info to be reproduced.
+Unfortunately, we are not able to investigate / fix bugs without a minimal reproduction, so if we don't hear back from
+you, we are going to close an issue that doesn't have enough info to be reproduced.
 
-You can file new issues by selecting from our [new issue templates](https://github.com/l-zeuch/yagpdb.vim/issues/new/choose) and filling out the issue template.
+You can file new issues by selecting from our
+[new issue templates](https://github.com/l-zeuch/yagpdb.vim/issues/new/choose) and filling out the issue template.
 
 ### <a name="submit-pr"></a> Submitting a Pull Request (PR)
 
@@ -53,38 +68,41 @@ Before you submit your Pull Request, follow these steps:
 1. Search [GitHub](https://github.com/l-zeuch/yagpdb.vim/pulls) for an open or closed PR that relates to your submission.
    You wouldn't want to duplicate existing efforts.
 
-2. Be sure that an issue describes the problem you're fixing, or documents the design for the feature you're adding.
+1. Be sure that an issue describes the problem you're fixing, or documents the design for the feature you're adding.
    Discussing the design upfront helps to ensure that we're ready to accept your work.
 
-3. [Fork](https://github.com/l-zeuch/yagpdb.vim/fork) and then clone your fork.
+1. [Fork](https://github.com/l-zeuch/yagpdb.vim/fork) and then clone your fork.
 
-4. Load in the clone of your fork via the plugin loader of your choice.
+1. Load in the clone of your fork via the plugin loader of your choice.
 
-5. In your cloned repository, make your changes in a new branch:
+1. In your cloned repository, make your changes in a new branch:
 
     ```shell
     git checkout -b my-branch master
     ```
 
-6. Make your changes, including tests when appropriate.
+1. Make your changes, including tests when appropriate.
 
-7. Make sure the tests are still passing locally. We use [vader.vim](https:/github.com/junegunn/vader.vim) as our testing framework. Run the tests using `make test`.
+1. Make sure the tests are still passing locally.
+    We use [vader.vim](https:/github.com/junegunn/vader.vim) as our testing framework. Run the tests using `make test`.
 
-8. Follow the current coding style as close as possible. Simply take a look at other files and stick to their styling.
+1. Follow the current coding style as close as possible. Simply take a look at other files and stick to their styling.
 
-9. Commit your changes using a descriptive commit message following our [commit message conventions](#commit).
+1. Commit your changes using a descriptive commit message following our [commit message conventions](#commit).
 
-10. Push your branch to GitHub:
+1. Push your branch to GitHub:
 
    ```shell
    git push origin my-branch
    ```
 
-11. On GitHub, send a pull request to `l-zeuch:master`.
+1. On GitHub, send a pull request to `l-zeuch:master`.
 
 ### Reviewing a Pull Request
 
-We reserve the right not to accept pull requests from community members who haven't been good citizens of the community; such behaviour includes not following the [Code of Conduct](.github/CODE_OF_CONDUCT.md) and applies within or outside this project's scope.
+We reserve the right not to accept pull requests from community members who haven't been good citizens of the community;
+such behaviour includes not following the [Code of Conduct](.github/CODE_OF_CONDUCT.md) and applies within or outside
+this project's scope.
 
 #### Addressing review feedback
 
@@ -92,7 +110,7 @@ If we ask for changes via code reviews then:
 
 1. Make the required updates to the code.
 
-2. Push the new changes to your repository (this will update your Pull Request as well)
+1. Push the new changes to your repository (this will update your Pull Request as well)
 
    ```shell
    git push --force-with-lease
@@ -108,7 +126,7 @@ Formatting commit messages according to a specification makes it easier to read 
 
 Each commit message consists of a header, a body, and a footer:
 
-```
+```txt
 <header>
 <blank line>
 <body>
@@ -122,9 +140,9 @@ The `body` is mandatory. The [commit body](#commit-body) structure describes how
 
 The `footer` is optional. The [commit footer](#commit-footer) format describes what the footer is used for.
 
-#### <a name="commit-header"></a> Commit Message Header
+## <a name="commit-header"></a> Commit Message Header
 
-```
+```txt
 <scope>: <short summary>
    |           |
    |           └─> Summary in present tense. Not capitalized. No period at the end.
@@ -133,11 +151,12 @@ The `footer` is optional. The [commit footer](#commit-footer) format describes w
          e.g. docs, syntax, folding, keybinds, github, legal, ...
 ```
 
-##### Scope
+### Scope
 
-The scope should be descriptive. If your commit contained multiple scopes, split them up appropriately and consider individual pull requests should they not depend on each other.
+The scope should be descriptive. If your commit contained multiple scopes, split them up appropriately and consider
+individual pull requests should they not depend on each other.
 
-##### Summary
+### Summary
 
 Use the summary field to provide a succinct description of the change:
 
@@ -145,18 +164,20 @@ Use the summary field to provide a succinct description of the change:
 * don't capitalize the first letter
 * no dot (.) at the end
 
-#### <a name="commit-body"></a> Commit Message Body
+### <a name="commit-body"></a> Commit Message Body
 
 Just as in the summary, use the imperative, present tense: "fix" not "fixed" nor "fixes".
 
-Explain the motivation for the change in the commit message body. This commit message should explain _why_ you are making the change.
+Explain the motivation for the change in the commit message body.
+This commit message should explain _why_ you are making the change.
 You can include a comparison of the previous behavior with the new behavior in order to illustrate the impact of the change.
 
-#### <a name="commit-footer"></a> Commit Message Footer
+### <a name="commit-footer"></a> Commit Message Footer
 
-The footer can contain information about breaking changes (if any) and is also the place to reference GitHub issues and other PRs that this commit closes or is related to, as well as Co-Authors:
+The footer can contain information about breaking changes (if any) and is also the place to reference GitHub issues
+and other PRs that this commit closes or is related to, as well as Co-Authors:
 
-```
+```txt
 BREAKING CHANGE: <breaking change summary>
 <blank line>
 <breaking change description + migrate instructions>
@@ -170,9 +191,9 @@ Co-authored-by: name <name@example.com>
 
 #### Revert commits
 
-If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit.
+If the commit reverts a previous commit, it should begin with `revert:`, followed by the header of the reverted commit.
 
 The content of the commit message body should contain:
 
-- information about the SHA of the commit being reverted in the following format: `This reverts commit <SHA>`,
-- a clear description of the reason for reverting the commit message.
+* information about the SHA of the commit being reverted in the following format: `This reverts commit <SHA>`,
+* a clear description of the reason for reverting the commit message.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you wish to install this for your Vim installation, but have Neovim installed
 `install-vim` target.
 
 ```shell
-$ wget https://raw.githubusercontent.com/l-zeuch/yagpdb.vim/master/Makefile && make install
+wget https://raw.githubusercontent.com/l-zeuch/yagpdb.vim/master/Makefile && make install
 ```
 
 See also as Greg Hurrell's excellent Youtube video: [Vim screencast #75: Plugin managers](https://www.youtube.com/watch?v=X2_R3uxDN6g).
@@ -34,15 +34,19 @@ Pathogen is more of a runtime path manager than a plugin manager. You must clone
 a specific location, and Pathogen makes sure they are available in Vim.
 
 1. In the terminal,
+
     ```bash
     git clone https://github.com/l-zeuch/yagpdb.vim.git ~/.vim/bundle/yagpdb.vim
     ```
+
 1. In your `vimrc`,
+
     ```vim
     call pathogen#infect()
     syntax on
     filetype plugin indent on
     ```
+
 </details>
 
 <details>
@@ -50,12 +54,15 @@ a specific location, and Pathogen makes sure they are available in Vim.
 
 1. Install Vundle, according to its instructions.
 1. Add the following text to your `vimrc`.
+
     ```vim
     call vundle#begin()
       Plugin 'l-zeuch/yagpdb.vim'
     call vundle#end()
     ```
+
 1. Restart Vim, and run the `:PluginInstall` statement to install your plugins.
+
 </details>
 
 <details>
@@ -63,12 +70,15 @@ a specific location, and Pathogen makes sure they are available in Vim.
 
 1. Install Vim-Plug, according to its instructions.
 1. Add the following text to your `vimrc`.
-```vim
-call plug#begin()
-  Plug 'l-zeuch/yagpdb.vim'
-call plug#end()
-```
+
+    ```vim
+    call plug#begin()
+      Plug 'l-zeuch/yagpdb.vim'
+    call plug#end()
+    ```
+
 1. Restart Vim, and run the `:PlugInstall` statement to install your plugins.
+
 </details>
 
 <details>
@@ -76,12 +86,15 @@ call plug#end()
 
 1. Install Dein, according to its instructions.
 1. Add the following text to your `vimrc`.
+
     ```vim
     call dein#begin()
       call dein#add('l-zeuch/yagpdb.vim')
     call dein#end()
     ```
+
 1. Restart Vim, and run the `:call dein#install()` statement to install your plugins.
+
 </details>
 
 ## Configuration
@@ -94,9 +107,10 @@ used as follows:
 ```vim
 let g:yagpdbcc_use_primary = 1
 ```
+
 ### Code Completion (Neovim >0.5 ONLY)
 
-We provide bundled sources for code-completion to be used with https://github.com/hrsh7th/nvim-cmp.
+We provide bundled sources for code-completion to be used with [hrsh7th/nvim-cmp](https://github.com/hrsh7th/nvim-cmp).
 Follow the installation instructions there and enable the source as follows:
 
 ```lua
@@ -121,7 +135,7 @@ let g:yagpdbcc_override_ft = 1
 We provide snippets for two distinct engines: [UltiSnips](https://github.com/SirVer/ultisnips),
 and [Neosnippet](https://github.com/Shougo/neosnippet.vim).
 
-Select which one to use by setting the `g:yagpdbcc_snippet_engine` variable to either ` ultisnips`, or `neosnippet`,
+Select which one to use by setting the `g:yagpdbcc_snippet_engine` variable to either `ultisnips`, or `neosnippet`,
 like so:
 
 ```vim

--- a/scripts/vint.py
+++ b/scripts/vint.py
@@ -57,7 +57,7 @@ def get_vint_output():
 
     try:
         process = subprocess.Popen(command, stdout = subprocess.PIPE)
-        output = process.stdout.read()
+        output = process.communicate()[0]
         process.wait()
 
         return output


### PR DESCRIPTION
This commit modifies the ci.yml file to use a matrix strategy to test across
multiple versions, both for Neovim and Vim. Secondly, it moves the former
test-nvim step to a separate job, in hopes that the pipeline will complete
faster.

The second part of this commit includes the new lint.yml file, which now
contains the former vim-lint job, as well as two new jobs; Linting via Pyright
for Python, and markdown via Markdownlint.

Future work might entail caching the dependencies on Vim and Neovim, so that we
can speed up the pipeline even further.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>


**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
