### PR TITLE
syntax: add missing functions

### DIFF
--- a/lua/yagpdbcc.lua
+++ b/lua/yagpdbcc.lua
@@ -143,6 +143,7 @@ function source:complete(params, callback)
 		{ label = 'sendMessage' },
 		{ label = 'sendMessageNoEscape' },
 		{ label = 'sendMessageNoEscapeRetID' },
+		{ label = 'sendMessageRetID' },
 		{ label = 'unpinMessage' },
 		{ label = 'adjective' },
 		{ label = 'carg' },

--- a/syntax/yagpdbcc/functions.vim
+++ b/syntax/yagpdbcc/functions.vim
@@ -67,7 +67,8 @@ syn keyword yagFunc deleteMessageReaction deleteResponse contained
 syn keyword yagFunc deleteTrigger editMessageNoEscape contained
 syn keyword yagFunc getMessage pinMessage sendDM contained
 syn keyword yagFunc sendMessage sendMessageNoEscape contained
-syn keyword yagFunc sendMessageNoEscapeRetID unpinMessage contained
+syn keyword yagFunc sendMessageNoEscapeRetID sendMessageRetID contained
+syn keyword yagFunc unpinMessage contained
 
 " Misc
 syn keyword yagFunc adjective carg cembed createTicket contained


### PR DESCRIPTION
This commit adds the `sendMessageRetID` function back, that might have gone
amiss with a past commit.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
