### PR TITLE
tests: add more test cases

### DIFF
--- a/autoload/yagpdbcc.vim
+++ b/autoload/yagpdbcc.vim
@@ -71,4 +71,3 @@ endfunction
 
 " Restore Vi compat
 let &cpoptions = s:cpo_save
-unlet s:cpo_save

--- a/autoload/yagpdbcc/config.vim
+++ b/autoload/yagpdbcc/config.vim
@@ -29,7 +29,7 @@ function! yagpdbcc#config#UsePrimary() abort
 endfunction
 
 function! yagpdbcc#config#SnippetEngine() abort
-    return get(g:, 'yagpdbcc_snippet_engine')
+    return get(g:, 'yagpdbcc_snippet_engine', '')
 endfunction
 
 " Restore Vi compat

--- a/autoload/yagpdbcc/config.vim
+++ b/autoload/yagpdbcc/config.vim
@@ -34,5 +34,3 @@ endfunction
 
 " Restore Vi compat
 let &cpoptions = s:cpo_save
-unlet s:cpo_save
-

--- a/autoload/yagpdbcc/snippets.vim
+++ b/autoload/yagpdbcc/snippets.vim
@@ -54,4 +54,3 @@ endfunction
 
 " Restore Vi compat
 let &cpoptions = s:cpo_save
-unlet s:cpo_save

--- a/syntax/yagpdbcc.vim
+++ b/syntax/yagpdbcc.vim
@@ -65,7 +65,7 @@ syn region      yagString           contained start=+"+
                                   \ skip=+\\\\\|\\"+ end=+"\|$+
                                   \ contains=@yagStringGroup,@Spell
 syn region      yagRawStr           contained start=#\v`# end=#\v`#
-                                  \ contains=@Spell fold
+                                  \ contains=yagFormat,@Spell fold
 
 hi def link     yagRawStr           yagString
 hi def link     yagString           String

--- a/test/autoload.vader
+++ b/test/autoload.vader
@@ -1,0 +1,45 @@
+# Test case file for autoloaded functions
+
+# Copyright (C) 2022    Lucas Ritzdorf, Luca Zeuch
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Language: YAGPDB Custom Commands
+# Maintainer: Luca Zeuch <l-zeuch@email.de>,
+#   LRitzdorf <42657792+LRitzdorf@users.noreply.github.com>
+
+Before:
+  source ../autoload/yagpdbcc.vim
+  source ../autoload/yagpdbcc/config.vim
+  source ../autoload/yagpdbcc/snippets.vim
+
+After:
+  Restore
+
+Execute (yagpdbcc#config#OverrideFt()):
+  AssertEqual 0, yagpdbcc#config#OverrideFt()
+
+Execute (yagpdbcc#config#UsePrimary()):
+  AssertEqual 0, yagpdbcc#config#UsePrimary()
+
+Execute (yagpdbcc#config#SnippetEngine()):
+  AssertEqual '', yagpdbcc#config#SnippetEngine()
+
+Execute (yagpdbcc#PathSep()):
+  if has('win32')
+    AssertEqual '\', yagpdbcc#PathSep()
+  else
+    AssertEqual '/', yagpdbcc#PathSep()
+  endif

--- a/test/autoload_config.vader
+++ b/test/autoload_config.vader
@@ -1,4 +1,4 @@
-# Test case file for autoloaded functions
+# Test case file for autoloaded config functions
 
 # Copyright (C) 2022    Lucas Ritzdorf, Luca Zeuch
 
@@ -21,14 +21,16 @@
 #   LRitzdorf <42657792+LRitzdorf@users.noreply.github.com>
 
 Before:
-  source ../autoload/yagpdbcc.vim
+  source ../autoload/yagpdbcc/config.vim
 
 After:
   Restore
 
-Execute (yagpdbcc#PathSep()):
-  if has('win32')
-    AssertEqual '\', yagpdbcc#PathSep()
-  else
-    AssertEqual '/', yagpdbcc#PathSep()
-  endif
+Execute (yagpdbcc#config#OverrideFt()):
+  AssertEqual 0, yagpdbcc#config#OverrideFt()
+
+Execute (yagpdbcc#config#UsePrimary()):
+  AssertEqual 0, yagpdbcc#config#UsePrimary()
+
+Execute (yagpdbcc#config#SnippetEngine()):
+  AssertEqual '', yagpdbcc#config#SnippetEngine()

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -285,20 +285,48 @@ Execute (exponents, imaginaries, pipes, format verbs):
 
 Given (custom embed with lots of nested syntax elements):
   {{ $embed := cembed
-      "title" (printf "User info: `%s`" $user.Username)
-      "description" "See below for details on this user."
-      "color" $color
-      "fields" (cslice
-          (sdict "name" "User ID" "value" (toString $user.ID) "inline" false)
-          (sdict "name" "Server nickname" "value" $nick "inline" false)
-          (sdict "name" "Server join info" "value" (printf "Joined on %s, %s ago" (formatTime $member.JoinedAt.Parse) (humanizeDurationHours (currentTime.Sub $member.JoinedAt.Parse))) "inline" false)
-      )
-      "thumbnail" (sdict "url" ($user.AvatarURL "256"))
-      "footer" (sdict "text" (printf "Account created %s, %s ago" (formatTime $created) (humanizeDurationHours (currentTime.Sub $created))))
+  "title" (printf "User info: `%s`" $user.Username)
+  "description" "See below for details on this user."
+  "color" $color
+  "fields" (cslice
+  (sdict "name" "User ID" "value" (toString $user.ID) "inline" false)
+  (sdict "name" "Server nickname" "value" $nick "inline" false)
+  (sdict "name" "Server join info" "value" (printf "Joined on %s, %s ago" (formatTime $member.JoinedAt.Parse) (humanizeDurationHours (currentTime.Sub $member.JoinedAt.Parse))) "inline" false)
+  )
+  "thumbnail" (sdict "url" ($user.AvatarURL "256"))
+  "footer" (sdict "text" (printf "Account created %s, %s ago" (formatTime $created) (humanizeDurationHours (currentTime.Sub $created))))
   }}
   {{ sendMessage nil $embed }}
 
-Execute (syntax check):
-# TODO (just pass for now)
-  AssertEqual 1, 1
+Execute (function match with deep structure):
+  AssertEqual 'yagFunc', SyntaxAt(1, 18), "Match function name in open-ended action"
+  AssertEqual 'yagFunc', SyntaxAt(2, 15), "Match function name on line continuation"
+  AssertEqual 'yagFunc', SyntaxAt(5, 16), "Match function name nested deep down"
+  AssertEqual 'yagFunc', SyntaxAt(6, 6), "Match function name deeply nested"
+  AssertEqual 'yagFunc', SyntaxAt(7, 6), "Match function name deeply nested"
+  AssertEqual 'yagFunc', SyntaxAt(8, 6), "Match function name deeply nested"
+  AssertEqual 'yagFunc', SyntaxAt(8, 136), "Match function name super deeply nested"
+  AssertEqual 'yagFunc', SyntaxAt(11, 114), "Match function name with method attached"
 
+Execute (string matches):
+  AssertEqual 'yagString', SyntaxAt(2, 17), "Match quoted strings"
+  AssertEqual 'yagString', SyntaxAt(2, 29), "Do not match quoted backticks"
+  AssertEqual 'yagFormat', SyntaxAt(2, 30), "Match format verbs identifier"
+  AssertEqual 'yagFormat', SyntaxAt(2, 31), "Match format verbs"
+  AssertEqual 'yagString', SyntaxAt(6, 12), "Match quoted sdict key names"
+  AssertEqual 'yagExpr', SyntaxAt(6, 24), "Do not expand string match followed by another string"
+  AssertEqual 'yagString', SyntaxAt(7, 12), "Match quoted sdict key names"
+  AssertEqual 'yagExpr', SyntaxAt(7, 32), "Do not expand string match followed by another string"
+  AssertEqual 'yagString', SyntaxAt(8, 181), "Match strings after a lot of syntax shenanigans"
+
+Execute (identifiers and objects):
+  AssertEqual 'yagIdentifier', SyntaxAt(2, 39), "Match identifiers with field"
+  AssertEqual 'yagExpr', SyntaxAt(2, 45), "Do not match fields as object"
+  AssertEqual 'yagIdentifier', SyntaxAt(7, 41), "Match identifiers between strings"
+  AssertEqual 'yagIdentifier', SyntaxAt(8, 85), "Match identifiers with fields + methods"
+  AssertEqual 'yagExpr', SyntaxAt(8, 92), "Do not match fields as object"
+  AssertEqual 'yagExpr', SyntaxAt(8, 101), "Do not match methods on fields as object"
+
+Execute (keywords and booleans):
+  AssertEqual 'yagBool', SyntaxAt(7, 56), "Match boolean values (false)"
+  AssertEqual 'yagKeyword', SyntaxAt(13, 16), "Match nil keyword"

--- a/test/syntax.vader
+++ b/test/syntax.vader
@@ -39,7 +39,7 @@ Before:
 After:
   Restore
 
-Given (code with comments):
+Given (code with a lot of comments):
   {{-   /*Initial $comment.test.asdf*/}}
   Normal text here
   {{/* How about {{ braces in }} comments? Looks good! */}}
@@ -53,7 +53,7 @@ Given (code with comments):
   */ -}}
   {{ print "This isn't valid syntax in the first place" /* asdf */}}
 
-Execute (syntax check):
+Execute (test comment matching):
 # Opening brace
   AssertEqual 'yagComment', SyntaxAt(1, 1), "Match comment region opening brace"
 
@@ -61,10 +61,12 @@ Execute (syntax check):
   AssertEqual 'yagComment', SyntaxAt(1, 37), "Comment region last match"
   AssertEqual '', SyntaxAt(2, 1), "Comment region actually ends"
 
+Execute (comment with embedded braces):
 # Ensure text inside and after the extra braces is still a comment
   AssertEqual 'yagComment', SyntaxAt(3, 19), "Comment region continues inside"
   AssertEqual 'yagComment', SyntaxAt(3, 32), "Comment region continues inside"
 
+Execute (test TODOs in comments only):
 # TODOs and FIXMEs, but only inside comments
   AssertEqual 'yagTodo', SyntaxAt(4, 6), "Match TODO inside comments"
   AssertEqual 'yagComment', SyntaxAt(4, 12), "Don't expand TODO match too far"
@@ -72,9 +74,7 @@ Execute (syntax check):
   AssertEqual 'yagTodo', SyntaxAt(6, 6), "Match FIXME inside comment"
   AssertEqual 'yagComment', SyntaxAt(6, 13), "Don't expand FIXME match too far"
 
-# a plain text area
-  AssertEqual '', SyntaxAt(7, 1), "Match plain text area with no syntax"
-
+Execute (multiline comments):
 # Multiline comments
   AssertEqual 'yagComment', SyntaxAt(7, 13), "Match multiline comment 1/5"
   AssertEqual 'yagComment', SyntaxAt(8, 1), "Match multiline comment 2/5"
@@ -82,6 +82,7 @@ Execute (syntax check):
   AssertEqual 'yagComment', SyntaxAt(11, 2), "Match multiline comment 4/5"
   AssertEqual 'yagComment', SyntaxAt(11, 5), "Match multiline comment 5/5"
 
+Execute (invalid comment syntax):
 # Don't match the invalid embedded comment syntax
   AssertEqual 'yagExpr', SyntaxAt(12, 58), "Don't match invalid embedded comment"
 
@@ -100,63 +101,67 @@ Given (normal code sample):
   {{ $escape_const := '\n' }}
   {{ $single_quote := '"' }}
 
-Execute (syntax check):
+Execute (test identifiers):
 # Validate syntax elements in the first and second lines
   AssertEqual 'yagIdentifier', SyntaxAt(1, 4), "Match identifier"
+# Validate the third line, with its non-standard format
+  AssertEqual 'yagIdentifier', SyntaxAt(3, 4), "Match identifer inside braces"
+
+Execute (test operators, numbers, and functions):
   AssertEqual 'yagOperator', SyntaxAt(1, 10), "Match operator"
   AssertEqual 'yagFunc', SyntaxAt(1, 13), "Match inbuilt function name"
   AssertEqual 'yagIntImg', SyntaxAt(1, 23), "Match number"
-  AssertEqual 'yagString', SyntaxAt(1, 27), "Match string"
   AssertEqual 'yagFunc', SyntaxAt(2, 6), "Match inbuilt function name w/ line continuation inside braces"
 
-# Validate the third line, with its non-standard format
-  AssertEqual 'yagIdentifier', SyntaxAt(3, 4), "Match identifer inside braces"
+Execute (test expression region):
   AssertEqual '', SyntaxAt(3, 19), "Don't match characters after closing brace"
   AssertEqual '', SyntaxAt(3, 37), "Don't match syntax keywords outside braces"
   AssertEqual '', SyntaxAt(3, 43), "Don't match numbers outside braces"
   AssertEqual '', SyntaxAt(3, 45), "Don't match strings outside braces"
+
+Execute (comment after multiple expressions):
   AssertEqual 'yagComment', SyntaxAt(3, 57), "Match comments inside braces"
 
-# Strings
+Execute (test string matching):
   AssertEqual 'yagString', SyntaxAt(2, 11), "Match string delimiter start w/ line continuation inside braces"
   AssertEqual 'yagString', SyntaxAt(2, 20), "Match string content w/ line continuation inside braces"
   AssertEqual '', SyntaxAt(2, 39), "Don't expand string match too far"
+  AssertEqual 'yagString', SyntaxAt(1, 27), "Match string"
 
+Execute (conditionals):
 # Check the new syntax elements in the following lines (no need to re-check
 # variable matching, for example - that's already been validated)
 # ifs and elses are part of the conditional group
   AssertEqual 'yagCond', SyntaxAt(4, 4), "Match conditional keyword inside braces"
 
-# The .Get method on line 5 isn't matched, so it's just part of a basic
-# expression region
-  AssertEqual 'yagFunc', SyntaxAt(5, 16), "Match inbuilt function name"
-  AssertEqual 'yagExpr', SyntaxAt(5, 30), "Don't match methods"
-  AssertEqual 'yagFunc', SyntaxAt(6, 18), "Match inbuilt function name"
-  AssertEqual 'yagCond', SyntaxAt(7, 4), "Match conditional keyword"
-  AssertEqual 'yagOperator', SyntaxAt(8, 14), "Match operator"
-
+Execute (objects and methods):
 # Objects, like .User and .Member, are matched as types
   AssertEqual 'yagObject', SyntaxAt(8, 16), "Match level-1 object"
   AssertEqual 'yagObject', SyntaxAt(9, 18), "Match level-1 object"
+# The .Get method on line 5 isn't matched, so it's just part of a basic
+# expression region
+  AssertEqual 'yagExpr', SyntaxAt(5, 30), "Don't match methods"
 
+Execute (keywords):
 # end is just a general keyword
   AssertEqual 'yagKeyword', SyntaxAt(10, 4), "Match `end` keyword"
 
-# Single character constants
+Execute (single character constants):
   AssertEqual 'yagChar', SyntaxAt(11, 21), "Match single character constant"
   AssertEqual 'yagChar', SyntaxAt(11, 22), "Match single character constant end delimiter"
   AssertEqual '', SyntaxAt(11, 26), "Don't expand character match too far"
 
-# Escape character constant
+
+Execute (escape sequence character constants):
   AssertEqual 'yagChar', SyntaxAt(12, 21), "Match first character of escape sequence in character constant"
   AssertEqual 'yagChar', SyntaxAt(12, 23), "Match character constant end delimiter"
   AssertEqual '', SyntaxAt(12, 27), "Don't expand character match too far"
 
+Execute (weird escape sequence ('"')):
 # This will be fun, '"' is really weird.
   AssertEqual 'yagChar', SyntaxAt(13, 21), "Match \" inside character constants"
   AssertEqual 'yagChar', SyntaxAt(13, 22), "Match character string delimiter"
   AssertEqual '', SyntaxAt(13, 26), "Don't expand match too far"
-
 
 Given (code with errors):
   {{ print "This is a common syntax mistake: " {{.User.Username}} }}
@@ -165,24 +170,26 @@ Given (code with errors):
   {{ $invalid_const := 'hello' }}
   {{ $funky_escape := '\n hmm' }}
 
-Execute (syntax check):
-# The classic beginner syntax mistake
+Execute (embedded braces):
   AssertEqual 'yagNestedBrace', SyntaxAt(1, 46), "Match error on nested braces"
   AssertEqual '', SyntaxAt(1, 66), "Don't expand error match too far"
 
-# Invalid Variable naming
+Execute (invalid identifier names):
   AssertEqual 'yagError', SyntaxAt(2, 43), "Match error on invalid identifier"
   AssertEqual '', SyntaxAt(2, 65), "Don't expand error too far"
 
+Execute (quoted single pair of braces inside braces):
 # Weird, but valid edge case
   AssertEqual 'yagString', SyntaxAt(3, 9), "Don't match \"{{\" as error"
   AssertEqual '', SyntaxAt(3, 22), "Don't expand string match too far"
 
+Execute (invalid character constants):
 # Invalid character constant
   AssertEqual 'yagCharError', SyntaxAt(4, 22), "Match error for multiple character constants"
   AssertEqual 'yagCharError', SyntaxAt(4, 23), "Match end delimiter as error as well"
   AssertEqual '', SyntaxAt(4, 31), "Don't expand error too far"
 
+Execute (proper limits on escape sequence matching):
 # Strange character constant edge case (just why)
   AssertEqual 'yagCharError', SyntaxAt(5, 21), "Match error on things like \'\n something\'"
   AssertEqual 'yagCharError', SyntaxAt(4, 27), "Match end delimiter as error as well"
@@ -199,14 +206,82 @@ Given (a variety of syntax elements):
   {{- printf `Long string with
   line breaks and
   formatting %d%%` 100 -}}
-  {{ add 1 -5e6 | mult (3e7i add 5E2) | printf "%s %d" ($args.Get 0).Username }}
-  {{.Message.Mentions.Asdf.Jkl}}
-  {{ $created := div $user.ID 4194304 | add 1420070400000 | mult 1000000 | toDuration | (newDate 1970 1 1 0 0 0).Add }}
+  {{ add 1 -5e6 | mult (add 3e7i 5E2) | printf "%s %d" ($args.Get 0).Username }}
 
-Execute (syntax check):
-# TODO (just pass for now)
-# Don't forget to check time functions and printf formatting
-  AssertEqual 1, 1
+Execute (empty identifier ($) and embedded action):
+# Test the funkyness of the first line, with a lot of constructs and
+# expression embedded into raw text.
+  AssertEqual '', SyntaxAt(1, 1), "Don't match raw text"
+  AssertEqual 'yagFunc', SyntaxAt(1, 31), "Match functions inside curly braces"
+  AssertEqual 'yagString', SyntaxAt(1, 37), "Match strings inside curly braces"
+  AssertEqual 'yagIdentifier', SyntaxAt(1, 45), "Match empty $ variable"
+  AssertEqual 'yagExpr', SyntaxAt(1, 51), "Match inside of curly braces"
+  AssertEqual '', SyntaxAt(1, 55), "Don't match outside of curly braces"
+
+Execute (objects and the dot):
+  AssertEqual 'yagObject', SyntaxAt(2, 4), "Match top-level objects"
+  AssertEqual 'yagExpr', SyntaxAt(2, 8), "Don't match second-level objects as yagObject"
+  AssertEqual 'yagDot', SyntaxAt(2, 16), "Match the standalone dot"
+  AssertEqual 'yagExpr', SyntaxAt(2, 17), "Don't expand the yagDot match too far"
+
+Execute (identifiers with numbers and underscores, $):
+  AssertEqual 'yagIdentifier', SyntaxAt(3, 4), "Match $ prefix of identifiers"
+  AssertEqual 'yagIdentifier', SyntaxAt(3, 5), "Match numbers in identifier names"
+  AssertEqual 'yagIdentifier', SyntaxAt(3, 6), "Match underscores in identifiers"
+  AssertEqual 'yagOperator', SyntaxAt(3, 12), "Match walrus' colon"
+  AssertEqual 'yagOperator', SyntaxAt(3, 13), "Match walrus' equal sign"
+  AssertEqual 'yagExpr', SyntaxAt(3, 14), "Don't match space behind operator"
+  AssertEqual 'yagIdentifier', SyntaxAt(3, 15), "Match standalone $ ident"
+
+Execute (escape sequences and dot hell):
+  AssertEqual 'yagExpr', SyntaxAt(4, 3), "Match the strip indicator as yagExpr"
+  AssertEqual 'yagFunc', SyntaxAt(4, 5), "Match inbuilt func after strip indicator"
+  AssertEqual 'yagString', SyntaxAt(4, 11), "Match strings inside curly braces"
+  AssertEqual 'yagEscape', SyntaxAt(4, 17), "Match escapes inside strings"
+  AssertEqual 'yagEscape', SyntaxAt(4, 18), "Match second char of escape sequence"
+  AssertEqual 'yagString', SyntaxAt(4, 19), "Do not match three chars as escapes"
+  AssertEqual 'yagDot', SyntaxAt(4, 26), "Match the dot as yagDot"
+  AssertEqual 'yagObject', SyntaxAt(4, 28), "Match dot of yagObjects"
+  AssertEqual 'yagExpr', SyntaxAt(4, 36), "Don't match the dot following anything"
+
+Execute (multiple strings one after another):
+  AssertEqual 'yagFunc', SyntaxAt(5, 4), "Match functions inside expressions"
+  AssertEqual 'yagEscape', SyntaxAt(5, 14), "Match escapes"
+  AssertEqual 'yagExpr', SyntaxAt(5, 16), "Don't expand your strings too far"
+  AssertEqual 'yagString', SyntaxAt(5, 17), "Match \" at begin of string"
+  AssertEqual 'yagExpr', SyntaxAt(5, 24), "Match \" at end of string and stop"
+  AssertEqual 'yagString', SyntaxAt(5, 25), "Match \" at begin of string"
+  AssertEqual 'yagExpr', SyntaxAt(5, 32), "Match \" at end of string and stop"
+
+Execute (printf, format verbs, hex numbers):
+  AssertEqual 'yagFunc', SyntaxAt(6, 4), "Match functions inside curly braces"
+  AssertEqual 'yagString', SyntaxAt(6, 12), "Match inside string delimiters"
+  AssertEqual 'yagFormat', SyntaxAt(6, 34), "Match % inside strings as yagFormat"
+  AssertEqual 'yagFormat', SyntaxAt(6, 35), "Match format verb as yagFormat"
+  AssertEqual 'yagExpr', SyntaxAt(6, 37), "Stop string match after closing \" "
+  AssertEqual 'yagHex', SyntaxAt(6, 38), "Match hex number 0x notation as yagHex"
+  AssertEqual 'yagHex', SyntaxAt(6, 39), "Match A-F / a-f as yagHex"
+  AssertEqual 'yagExpr', SyntaxAt(6, 42), "Stop yagHex match after last hex num"
+
+Execute (booleans):
+  AssertEqual 'yagBool', SyntaxAt(7, 29), "Match true/false as yagBool"
+  AssertEqual 'yagExpr', SyntaxAt(7, 33), "Stop yagBool match after end of word"
+
+Execute (multiline strings):
+  AssertEqual 'yagExpr', SyntaxAt(8, 3), "Match strip indicator as yagExpr"
+  AssertEqual 'yagFunc', SyntaxAt(8, 5), "Match functions"
+  AssertEqual 'yagExpr', SyntaxAt(8, 11), "Stop yagFunc match after end of word"
+  AssertEqual 'yagRawStr', SyntaxAt(8,12), "Match raw strings (\`)"
+  AssertEqual 'yagRawStr', SyntaxAt(9, 1), "Multiline raw strings"
+  AssertEqual 'yagRawStr', SyntaxAt(10, 1), "Multiline raw strings"
+  AssertEqual 'yagFormat', SyntaxAt(10, 12), "Match format verbs inside raw strings"
+  AssertEqual 'yagExpr', SyntaxAt(10, 17), "Don't expand raw string too far"
+
+Execute (exponents, imaginaries, pipes, format verbs):
+  AssertEqual 'yagIntImg', SyntaxAt(11, 8), "Match single numbers as yagIntImg"
+  AssertEqual 'yagIntImg', SyntaxAt(11, 12), "Match exponential notation (XeY)"
+  AssertEqual 'yagIntImg', SyntaxAt(11, 30), "Match imaginary notation (Xi)"
+  AssertEqual 'yagIntImg', SyntaxAt(11, 33), "Match exponential notation (xEy)"
 
 Given (custom embed with lots of nested syntax elements):
   {{ $embed := cembed


### PR DESCRIPTION
This patchset adds a plethora of tests to the already existing `syntax.vader` test suite, making extensive use of the `Execute` block to have more granular feedback.

Additionally, it adds a new `autoload.vader` test suite, testing a few of our autoloaded functions for correctness and expected return value.

In the process of adding new tests with regards to how YAGPDB itself handles it, I've also applied appropriate patches to the respective file.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
