### PR TITLE
autoload: document autoloaded functions

### DIFF
--- a/autoload/yagpdbcc.vim
+++ b/autoload/yagpdbcc.vim
@@ -20,7 +20,9 @@
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
-" Quick function and command to copy the whole file to the system clipboard
+" yagpdbcc#Copy copies the content of the current buffer to the user clipboard
+" register * or +, minus the trailing newline for each file.
+" It echoes an error if Vim is compiled without clipboard support.
 function! yagpdbcc#Copy() abort
     if has('clipboard')
         if yagpdbcc#config#UsePrimary() != 0
@@ -38,7 +40,15 @@ function! yagpdbcc#Copy() abort
     endif
 endfunction
 
-" Make jumping between sections work nicely
+" yagpdbcc#NextSection eases jumping between sections, i.e. actions.
+" It takes three arguments: type, backwards, visual.
+"
+" type 1 sets the pattern to match the start of line, and jump to beginning of
+" word. type 2 jumps to EOL.
+"
+" backwards is a boolean: 0 for forwards, 1 for backwards.
+"
+" visual is a boolean: 0 if in normal mode, 1 if in visual mode.
 function! yagpdbcc#NextSection(type, backwards, visual) abort
     if a:visual
         normal! gv
@@ -61,6 +71,8 @@ function! yagpdbcc#NextSection(type, backwards, visual) abort
     execute 'silent normal! ' . l:dir . l:pattern . l:dir . l:flags . '\r'
 endfunction
 
+" yagpdbcc#PathSep returns the OSs path separator.
+" For Microsoft Windows, that is \, for UNIX and UNIX-like it is /.
 function! yagpdbcc#PathSep() abort
     if has('win32')
         return '\'

--- a/autoload/yagpdbcc/config.vim
+++ b/autoload/yagpdbcc/config.vim
@@ -20,14 +20,25 @@
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
+" yagpdbcc#config#OverrideFt returns the value of the global
+" yagpdbcc_override_ft variable used to determine whether to override more
+" filetypes.
+" Its default return value is 0.
 function! yagpdbcc#config#OverrideFt() abort
 	return get(g:, 'yagpdbcc_override_ft')
 endfunction
 
+" yagpdbcc#config#UsePrimary returns the value of the global
+" yagpdbcc_use_primary variable used to determine whether to use the * or +
+" register.
+" Its default return value is 0.
 function! yagpdbcc#config#UsePrimary() abort
 	return get(g:, 'yagpdbcc_use_primary')
 endfunction
 
+" yagpdbcc#config#SnippetEngine returns the value of the global
+" yagpdbcc_snippet_engine variable used to determine what snippet engine to use.
+" Its default return value is an empty string ''.
 function! yagpdbcc#config#SnippetEngine() abort
     return get(g:, 'yagpdbcc_snippet_engine', '')
 endfunction

--- a/autoload/yagpdbcc/snippets.vim
+++ b/autoload/yagpdbcc/snippets.vim
@@ -20,6 +20,9 @@
 let s:cpo_save = &cpoptions
 set cpoptions&vim
 
+" yagpdbcc#snippets#UltiSnips sets up a minimal functioning UltiSnips
+" configuration for use with our snippets.
+" It does not return anything.
 function! yagpdbcc#snippets#UltiSnips() abort
     if get(g:, 'did_plugin_ultisnip') isnot 1
         return
@@ -32,6 +35,9 @@ function! yagpdbcc#snippets#UltiSnips() abort
     endif
 endfunction
 
+" yagpdbcc#snippets#Neosnippet sets up a minimal functioning Neosnippet
+" configuration for use with our snippets.
+" It does not return anything.
 function! yagpdbcc#snippets#Neosnippet() abort
     if get(g:, 'loaded_neosnippet') isnot 1
         return


### PR DESCRIPTION
This commit adds small informative comments to each function within the autoload
directory, documenting their functionality, arguments, and return values.

This is just a relatively small change but I was bored and documentation is always good.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
