### PR TITLE
indent: add indentation logic

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 /syntax/                @LRitzdorf
 /autoload/              @l-zeuch
 /plugin/                @l-zeuch
+/indent/                @l-zeuch
 
 # Code completion
 /lua/                   @l-zeuch

--- a/indent/yagpdbcc.vim
+++ b/indent/yagpdbcc.vim
@@ -58,7 +58,7 @@ function! GetYagIndent(lnum) abort
 
     " These keywords indent the next lines.
     let l:last_line = getline(a:lnum-1)
-    if l:last_line =~# '^\s*{{-\=\s*\%(if\|else\|with\|try\|range\|while\|define\|template\|block\).*}}'
+    if l:last_line =~# '^\s*{{-\=\s*\%(if\|else\|with\|try\|catch\|range\|while\|define\|block\).*}}'
         let l:indent += shiftwidth()
     endif
 

--- a/indent/yagpdbcc.vim
+++ b/indent/yagpdbcc.vim
@@ -1,0 +1,76 @@
+" Vim indent file
+
+" Copyright (C) 2021    Lucas Ritzdorf, Luca Zeuch
+
+" This program is free software; you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation; either version 2 of the License, or
+" (at your option) any later version.
+
+" This program is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+
+" You should have received a copy of the GNU General Public License along
+" with this program; if not, write to the Free Software Foundation, Inc.,
+" 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+" Language: YAGPDB Custom Commands
+" Maintainer: Luca Zeuch <l-zeuch@email.de>
+
+" This indent script is based on
+" https://github.com/fatih/vim-go/blob/master/indent/gohtmltmpl.vim, as that is
+" what YAGPDB custom commands in essence are.
+
+if exists('b:did_indent')
+    finish
+endif
+
+" YAGPDB Custom Commands use the Go text/template package, which in turn is just
+" fancy HTML templates. This works quite well.
+runtime! indent/html.vim
+
+" No suitable inbuilt solution, so we'll have to tell Vim what to actually do.
+setlocal indentexpr=GetYagIndent(v:lnum)
+setlocal indentkeys+==else,=end
+
+" Only define indent function once.
+if exists('*GetYagIndent')
+    finish
+endif
+
+" Don't spam the user in Vi compat
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
+" Though functions should usually go into autoload/, this one is an exception.
+function! GetYagIndent(lnum) abort
+
+    let l:indent = 0
+
+    if exists('*HtmlIndent')
+        let l:indent = HtmlIndent()
+    else
+        let l:indent = HtmlIndentGet(a:lnum)
+    endif
+
+    " These keywords indent the next lines.
+    let l:last_line = getline(a:lnum-1)
+    if l:last_line =~# '^\s*{{-\=\s*\%(if\|else\|with\|try\|range\|while\|define\|template\|block\).*}}'
+        let l:indent += shiftwidth()
+    endif
+
+    " These keywords need to be outdented once, so that they start in the same
+    " column as their indenting counterpart.
+    let l:current_line = getline(a:lnum)
+    if l:current_line =~# '^\s*{{-\=\s*\%(else\|catch\|end\).*}}'
+        let l:indent -= shiftwidth()
+    endif
+
+    return l:indent
+endfunction
+
+" Restore Vi compat
+let &cpoptions = s:cpo_save
+unlet s:cpo_save

--- a/indent/yagpdbcc.vim
+++ b/indent/yagpdbcc.vim
@@ -47,7 +47,8 @@ set cpoptions&vim
 " Though functions should usually go into autoload/, this one is an exception.
 function! GetYagIndent(lnum) abort
 
-    let l:indent = 0
+    " If nothing needs indenting, keep current indent
+    let l:indent = -1
 
     if exists('*HtmlIndent')
         let l:indent = HtmlIndent()

--- a/test/indent.vader
+++ b/test/indent.vader
@@ -1,0 +1,157 @@
+# Test case file for indentation
+
+# Copyright (C) 2022 Lucas Ritzdorf, Luca Zeuch
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+# Language: YAGPDB Custom Commands
+# Maintainer: Luca Zeuch <l-zeuch@email.de>,
+#   LRitzdorf <42657792+LRitzdorf@users.noreply.github.com>
+
+Before:
+  source ../indent/yagpdbcc.vim
+
+After:
+  Restore
+
+Given (simple code with no indents):
+  {{ if true }}
+  {{ print "hello" }}
+  {{ else }}
+  {{ print "bye" }}
+  {{ end }}
+
+Do (apply indents):
+  gg=G
+
+Expect (indented code):
+  {{ if true }}
+    {{ print "hello" }}
+  {{ else }}
+    {{ print "bye" }}
+  {{ end }}
+
+Given (code with indents all over the place):
+  {{ if false }}
+          {{/* do stuff */}}
+          {{ template "my_template" }}
+          {{ return }}
+        {{ else }}
+    {{ sendMessage nil "something broke :(" }}
+    {{ dbSet 2000 "key" "value" }}
+      {{ end }}
+
+Do (apply indents):
+  gg=G
+
+Expect (fixed indents):
+  {{ if false }}
+    {{/* do stuff */}}
+    {{ template "my_template" }}
+    {{ return }}
+  {{ else }}
+    {{ sendMessage nil "something broke :(" }}
+    {{ dbSet 2000 "key" "value" }}
+  {{ end }}
+
+Given (code with raw strings):
+  {{ if $something }}
+  do stuff
+  {{/* hello */}}
+  {{ $r := `
+  eeee
+  e
+  e
+  e
+  e
+  e
+  e
+  `}}
+  {{ else }}
+  {{ if yes }}
+  epic
+  {{ else }}
+  also epic
+  {{ end }}
+  {{ end }}
+  {{ range }}
+  k
+  {{ end }}
+
+Do (apply indents):
+  gg=G
+
+Expect (neat indentation):
+  {{ if $something }}
+    do stuff
+    {{/* hello */}}
+    {{ $r := `
+    eeee
+    e
+    e
+    e
+    e
+    e
+    e
+    `}}
+  {{ else }}
+    {{ if yes }}
+      epic
+    {{ else }}
+      also epic
+    {{ end }}
+  {{ end }}
+  {{ range }}
+    k
+  {{ end }}
+
+Given (deep nests all over the place):
+  {{ try }}
+  {{ sendmessage 12345 "this might fail" }}
+  {{ catch }}
+  {{ sendmessage nil "stuff failed :/" }}
+  {{ end }}
+  {{ define "my_stuff" }}
+  {{ range $some_slice }}
+  {{ if eq . $something_else }}
+  {{ return }}
+  {{ else }}
+  {{ while true }}
+  {{ return }}
+  {{ end }}
+  {{ end }}
+  {{ end }}
+  {{ end }}
+
+Do (apply indents):
+  gg=G
+
+Expect (readable code):
+  {{ try }}
+    {{ sendmessage 12345 "this might fail" }}
+  {{ catch }}
+    {{ sendmessage nil "stuff failed :/" }}
+  {{ end }}
+  {{ define "my_stuff" }}
+    {{ range $some_slice }}
+      {{ if eq . $something_else }}
+        {{ return }}
+      {{ else }}
+        {{ while true }}
+          {{ return }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  {{ end }}

--- a/test/vimrc
+++ b/test/vimrc
@@ -29,3 +29,6 @@ syntax enable
 set nomore
 set noswapfile
 set viminfo=
+
+set shiftwidth=2
+set expandtab


### PR DESCRIPTION
This commit adds an indentexpr to tell Vim how to properly indent YAGPDB-CC code.
The script is based on fatih/vim-go's gohtmltmpl.vim indentexpr, 
which YAGPDB custom commands essentially are. Proper credit has been given.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
