### PR TITLE
syntax: add new functions (v2.8.0)

### DIFF
--- a/lua/yagpdbcc.lua
+++ b/lua/yagpdbcc.lua
@@ -205,6 +205,7 @@ function source:complete(params, callback)
 		{ label = 'newDate' },
 		{ label = 'snowflakeToTime' },
 		{ label = 'weekNumber' },
+		{ label = 'timestampToTime' },
 		{ label = 'json' },
 		{ label = 'structToSdict' },
 		{ label = 'toByte' },

--- a/syntax/yagpdbcc/functions.vim
+++ b/syntax/yagpdbcc/functions.vim
@@ -104,6 +104,7 @@ syn keyword yagFunc humanizeDurationSeconds contained
 syn keyword yagFunc humanizeTimeSinceDays contained
 syn keyword yagFunc loadLocation newDate contained
 syn keyword yagFunc snowflakeToTime weekNumber contained
+syn keyword yagFunc timestampToTime contained
 
 " Type conversion
 syn keyword yagFunc json structToSdict toByte toDuration contained


### PR DESCRIPTION
YAGPDB version 2.8.0 adds one new function to their custom command system, `timestampToTime`.

This commit adds these/this new function(s) to the syntax definition.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
