### PR TITLE
syntax: add missing `cancelScheduledUniqueCC`

### DIFF
--- a/lua/yagpdbcc.lua
+++ b/lua/yagpdbcc.lua
@@ -45,6 +45,23 @@ end
 ---@param callback fun(response: lsp.CompletionResponse|nil)
 function source:complete(params, callback)
     callback({
+		{ label = 'if' },
+		{ label = 'else' },
+		{ label = 'with' },
+		{ label = 'try' },
+		{ label = 'catch' },
+		{ label = 'true' },
+		{ label = 'false' },
+		{ label = 'range' },
+		{ label = 'while' },
+		{ label = 'define' },
+		{ label = 'template' },
+		{ label = 'block' },
+		{ label = 'nil' },
+		{ label = 'end' },
+		{ label = 'return' },
+		{ label = 'break' },
+		{ label = 'continue' },
 		{ label = 'bitwiseAnd' },
 		{ label = 'bitwiseOr' },
 		{ label = 'bitwiseXor' },
@@ -159,6 +176,7 @@ function source:complete(params, callback)
 		{ label = 'hasPrefix' },
 		{ label = 'execTemplate' },
 		{ label = 'verb' },
+		{ label = 'cancelScheduledUniqueCC' },
 		{ label = 'addRoleID' },
 		{ label = 'addRoleName' },
 		{ label = 'getRole' },
@@ -222,24 +240,7 @@ function source:complete(params, callback)
 		{ label = 'currentUserCreated' },
 		{ label = 'pastNicknames' },
 		{ label = 'pastUsernames' },
-		{ label = 'userArg' },
-		{ label = 'if' },
-		{ label = 'else' },
-		{ label = 'with' },
-		{ label = 'try' },
-		{ label = 'catch' },
-		{ label = 'true' },
-		{ label = 'false' },
-		{ label = 'range' },
-		{ label = 'while' },
-		{ label = 'define' },
-		{ label = 'template' },
-		{ label = 'block' },
-		{ label = 'nil' },
-		{ label = 'end' },
-		{ label = 'return' },
-		{ label = 'break' },
-		{ label = 'continue' }
+		{ label = 'userArg' }
     })
 end
 

--- a/syntax/yagpdbcc/functions.vim
+++ b/syntax/yagpdbcc/functions.vim
@@ -79,6 +79,7 @@ syn keyword yagFunc sendTemplate sendTemplateDM seq range contained
 syn keyword yagFunc shuffle sleep sort execCC contained
 syn keyword yagFunc scheduleUniqueCC hasPrefix contained
 syn keyword yagFunc execTemplate verb contained
+syn keyword yagFunc cancelScheduledUniqueCC contained
 
 " Role
 syn keyword yagFunc addRoleID addRoleName getRole contained


### PR DESCRIPTION
`cancelScheduledUniqueCC` was missing (perhaps accidentally removed), this commit adds it (back).

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
