### PR TITLE
autoload: move utility functions to their own namespace

### DIFF
--- a/autoload/yagpdbcc.vim
+++ b/autoload/yagpdbcc.vim
@@ -34,9 +34,7 @@ function! yagpdbcc#Copy() abort
             let @+=substitute(@+,'\n$','','')
         endif
     else
-        echohl Error
-        echo "Your Vim doesn't appear to have clipboard support."
-        echohl None
+        call yagpdbcc#util#Error("Your Vim doesn't appear to have clipboard support.")
     endif
 endfunction
 

--- a/autoload/yagpdbcc.vim
+++ b/autoload/yagpdbcc.vim
@@ -34,7 +34,7 @@ function! yagpdbcc#Copy() abort
             let @+=substitute(@+,'\n$','','')
         endif
     else
-        call yagpdbcc#util#Error("Your Vim doesn't appear to have clipboard support.")
+        call yagpdbcc#util#Error('Your Vim doesn't appear to have clipboard support.')
     endif
 endfunction
 

--- a/autoload/yagpdbcc.vim
+++ b/autoload/yagpdbcc.vim
@@ -34,7 +34,7 @@ function! yagpdbcc#Copy() abort
             let @+=substitute(@+,'\n$','','')
         endif
     else
-        call yagpdbcc#util#Error('Your Vim doesn't appear to have clipboard support.')
+        call yagpdbcc#util#Error("Your Vim doesn't appear to have clipboard support.")
     endif
 endfunction
 

--- a/autoload/yagpdbcc.vim
+++ b/autoload/yagpdbcc.vim
@@ -71,15 +71,5 @@ function! yagpdbcc#NextSection(type, backwards, visual) abort
     execute 'silent normal! ' . l:dir . l:pattern . l:dir . l:flags . '\r'
 endfunction
 
-" yagpdbcc#PathSep returns the OSs path separator.
-" For Microsoft Windows, that is \, for UNIX and UNIX-like it is /.
-function! yagpdbcc#PathSep() abort
-    if has('win32')
-        return '\'
-    endif
-
-    return '/'
-endfunction
-
 " Restore Vi compat
 let &cpoptions = s:cpo_save

--- a/autoload/yagpdbcc/config.vim
+++ b/autoload/yagpdbcc/config.vim
@@ -39,8 +39,16 @@ endfunction
 " yagpdbcc#config#SnippetEngine returns the value of the global
 " yagpdbcc_snippet_engine variable used to determine what snippet engine to use.
 " Its default return value is an empty string ''.
+" Available snippet engines are ultisnips and neosnippet.
 function! yagpdbcc#config#SnippetEngine() abort
-    return get(g:, 'yagpdbcc_snippet_engine', '')
+    let l:engine = get(g:, 'yagpdbcc_snippet_engine', '')
+
+    if l:engine isnot? '' && l:engine isnot? 'ultisnips' && l:engine isnot? 'neosnippet'
+        call yagpdbcc#util#Warn(l:engine . " is not a supported snippet engine.")
+        return ''
+    endif
+
+    return l:engine
 endfunction
 
 " Restore Vi compat

--- a/autoload/yagpdbcc/config.vim
+++ b/autoload/yagpdbcc/config.vim
@@ -44,7 +44,7 @@ function! yagpdbcc#config#SnippetEngine() abort
     let l:engine = get(g:, 'yagpdbcc_snippet_engine', '')
 
     if l:engine isnot? '' && l:engine isnot? 'ultisnips' && l:engine isnot? 'neosnippet'
-        call yagpdbcc#util#Warn(l:engine . " is not a supported snippet engine.")
+        call yagpdbcc#util#Warn(l:engine . ' is not a supported snippet engine.')
         return ''
     endif
 

--- a/autoload/yagpdbcc/util.vim
+++ b/autoload/yagpdbcc/util.vim
@@ -34,14 +34,14 @@ endfunction
 " yagpbcc#util#Error takes a string argument and highlights it as error.
 function! yagpdbcc#util#Error(msg) abort
     echohl ErrorMsg
-        echo "[yagpdb.vim]: " . a:msg
+        echo '[yagpdb.vim]: ' . a:msg
     echohl None
 endfunction
 
 " yagpdbcc#util#Warn takes a string argument and highlights it as warning.
 function! yagpdbcc#util#Warn(msg) abort
     echohl WarningMsg
-        echo "[yagpdb.vim]: " . a:msg
+        echo '[yagpdb.vim]: ' . a:msg
     echohl None
 endfunction
 

--- a/autoload/yagpdbcc/util.vim
+++ b/autoload/yagpdbcc/util.vim
@@ -1,0 +1,49 @@
+" Autoloading file various utilities.
+
+" Copyright (C) 2022    Lucas Ritzdorf, Luca Zeuch
+
+" This program is free software; you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation; either version 2 of the License, or
+" (at your option) any later version.
+
+" This program is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+" GNU General Public License for more details.
+
+" You should have received a copy of the GNU General Public License along
+" with this program; if not, write to the Free Software Foundation, Inc.,
+" 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+" Don't spam the user when Vim is started in Vi compat
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
+
+" yagpdbcc#PathSep returns the OSs path separator.
+" For Microsoft Windows, that is \, for UNIX and UNIX-like it is /.
+function! yagpdbcc#util#PathSep() abort
+    if has('win32')
+        return '\'
+    endif
+
+    return '/'
+endfunction
+
+" yagpbcc#util#Error takes a string argument and highlights it as error.
+function! yagpdbcc#util#Error(msg) abort
+    echohl ErrorMsg
+        echo "[yagpdb.vim]: " . a:msg
+    echohl None
+endfunction
+
+" yagpdbcc#util#Warn takes a string argument and highlights it as warning.
+function! yagpdbcc#util#Warn(msg) abort
+    echohl WarningMsg
+        echo "[yagpdb.vim]: " . a:msg
+    echohl None
+endfunction
+
+" Restore Vi compat
+let &cpoptions = s:cpo_save


### PR DESCRIPTION
This patchset moves utility functions to their own namespace `yagpdbcc#util`.
Further it adds two new functions `Error` and `Warn`.

Lastly, these changes are reflected onto the callsites of the respective function.

Additionally, it adds a check for the given snippet engine and warns the user about an unsupported engine.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
