### PR TITLE
scripts/vint: exclude `.bundle` from linter

### DIFF
--- a/scripts/vint.py
+++ b/scripts/vint.py
@@ -19,6 +19,7 @@ import json
 import shutil
 import subprocess
 import sys
+import glob
 
 # Generate our vint command and fail if the executable is not found.
 def generate_command():
@@ -28,7 +29,10 @@ def generate_command():
         print("No vint executable found. Install it with pip install vim-vint.")
         sys.exit(1)
 
-    return [exe, "--json", "."]
+    files = glob.glob('**/*.vim', recursive=True)
+    cmd = [exe, "--json"]
+    cmd.extend(files)
+    return cmd
 
 def generate_github_output(issues):
     # Map Vint's levels to GitHub's message levels.


### PR DESCRIPTION
With the current implementation, developers who keep the `.bundle` directory around and run `make lint`, vint will also be invoked on that directory.

This behaviour is undesirable and confusing -- thus, this commit changes the construction of the command to first glob the project tree for any Vim Script files. Given how globbing a path ignores dotfiles, this was quite straightforward.

The only downside is that now the command is *very* long, however that should not be an issue -- in fact, I believe it is better that way, because it becomes immediately obvious which files were linted, even when no violations were found.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
