### PR TITLE
build: deal with Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,23 @@ Syntax highlighting for [YAGPDB](https://yagpdb.xyz) custom commands in (N)Vim.
 
 ### Manually
 
-To install without any external plugin-manager dependencies, simply download the `Makefile` and run `make install`.
-If you wish to install this for your Vim installation, but have Neovim installed as well, make sure to use the
-`install-vim` target.
+To install without any external plugin-manager dependencies, simply download the `Makefile` and run `make install`. For a
+different destination, invoke `make` with `DESTDIR=/path/to/destination`.
 
 ```shell
 wget https://raw.githubusercontent.com/l-zeuch/yagpdb.vim/master/Makefile && make install
 ```
 
+> **Note**
+> If you wish to install this for your Vim, but also have Neovim installed, make sure to invoke the `install-vim` target
+> instead.
+
 See also as Greg Hurrell's excellent Youtube video: [Vim screencast #75: Plugin managers](https://www.youtube.com/watch?v=X2_R3uxDN6g).
 
 ### With a Plugin Manager
+
+> **Note**
+> Installing with a plugin manager is recommended for Windows installations.
 
 Use your favorite plugin manager to install this plugin. [tpope/vim-pathogen](https://github.com/tpope/vim-pathogen),
 [VundleVim/Vundle.vim](https://github.com/VundleVim/Vundle.vim), [junegunn/vim-plug](https://github.com/junegunn/vim-plug),


### PR DESCRIPTION
Conditionally assign important variables, i.e. python3, nvim, vim, git. That way, developers and users alike can use their own specific programs if required.

Furthermore add support for a DESTDIR which can be user-defined as well during invocation of make. This makes dealing with Windows less of a pain.

Smartly clone to DESTDIR, depending on installation target (Vim vs. Neovim). Give users advice on how to proceed if Windows appears to be running as OS.

We now recursively call out to install-vim and install-nvim. This makes the parent install target cleaner and clarifies what is going on.

Closes l-zeuch/yagpdb.vim#48 ("Proposal: Makefile: Deal with Windows")


**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
