### PR TITLE
ci: test against new (n)vim releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [v0.5.0, v0.6.0, v0.7.0, stable]
+        version: [v0.5.0, v0.6.0, v0.7.0, v0.8.0, stable]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install latest Vim stable
+      - name: Install Vim ${{ matrix.version }}
         uses: rhysd/action-setup-vim@v1
         with:
           version: ${{ matrix.version }}
@@ -67,7 +67,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Install latest Neovim
+      - name: Install Neovim ${{ matrix.version }}
         uses: rhysd/action-setup-vim@v1
         with:
           neovim: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [v8.0.0000, v8.2.0000, v9.0.0000, stable]
+        # 8.2.2434 is the current version on Debian Bullseye and its
+        # derivatives.
+        version: [v8.0.0000, v8.2.0000, v8.2.2434, v9.0.0000, stable]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,9 +36,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
+      - name: Ensure pip is installed
+        run: |
+          apt update -y && apt install python3-pip -y
+
       - name: Install vim-vint
         run: |
-          python -m pip install --upgrade pip
+          python3 -m pip install --upgrade pip
           pip install vim-vint
 
       - name: Run VimL linter

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Ensure pip is installed
         run: |
-          apt update -y && apt install python3-pip -y
+          sudo apt update -y && sudo apt install python3-pip -y
 
       - name: Install vim-vint
         run: |


### PR DESCRIPTION
Add nvim-0.8 to version matrix of the test-nvim job.

Latest stable Neovim release is 0.9; without this change, we'd be
skipping over 0.8 during tests, potentially risking compatibility
issues.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
