### PR TITLE
ftdetect: drop support for unnecessary file exts

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,17 @@ sources = cmp.config.sources({
     ...
 })
 ```
+### Supported File Extensions
+
+We support the following list of file extensions:
+
+- `*.yag`
+- `*.yagcc`
+- `*.tmpl` <sup>1)</sup>
+- `*.go.tmpl` <sup>1)</sup>
+
+<sup>1)</sup> These extensions are not detected by default, as they are already used by Go. Please see below for instructions on how to
+enable them.
 
 ### Overriding Filetypes
 

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ sources = cmp.config.sources({
     ...
 })
 ```
+
 ### Supported File Extensions
 
 We support the following list of file extensions:
@@ -135,8 +136,8 @@ We support the following list of file extensions:
 - `*.tmpl` <sup>1)</sup>
 - `*.go.tmpl` <sup>1)</sup>
 
-<sup>1)</sup> These extensions are not detected by default, as they are already used by Go. Please see below for instructions on how to
-enable them.
+<sup>1)</sup> These extensions are not detected by default, as they are already used by Go. Please see below for
+instructions on how to enable them.
 
 ### Overriding Filetypes
 

--- a/ftdetect/yagpdbcc.vim
+++ b/ftdetect/yagpdbcc.vim
@@ -31,11 +31,7 @@ set cpoptions&vim
 " Detect our 'own' extensions, which are usually used by a
 " vast majority of the userbase.
 au BufRead,BufNewFile   *.yag         setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagpdb      setfiletype yagpdbcc
 au BufRead,BufNewFile   *.yagcc       setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yag-cc      setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagpdbcc    setfiletype yagpdbcc
-au BufRead,BufNewFile   *.yagpdb-cc   setfiletype yagpdbcc
 
 " Also use *.tmpl, *.gotmpl et al., which are originally only Go, if configured.
 " Here, we need to explicitly override the default syntax - "setfiletype"


### PR DESCRIPTION
**Please describe the changes this pull request does and why it should be merged:**

Drop support for unnecessary file extensions, as they are too long
and/or confusing / redundant.

Closes #79

Breaking Change:
Support for the following file extensions will be dropped:
* yagpdb
* yagpdbcc
* yag-cc
* yagpdb-cc

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
