### PR TITLE
syntax/funcs: add publishMessage, publishResponse

### DIFF
--- a/lua/yagpdbcc.lua
+++ b/lua/yagpdbcc.lua
@@ -129,6 +129,8 @@ function source:complete(params, callback)
 		{ label = 'sendMessageNoEscapeRetID' },
 		{ label = 'sendMessageRetID' },
 		{ label = 'unpinMessage' },
+		{ label = 'publishMessage' },
+		{ label = 'publishResponse' },
 		{ label = 'adjective' },
 		{ label = 'carg' },
 		{ label = 'cembed' },

--- a/syntax/yagpdbcc/functions.vim
+++ b/syntax/yagpdbcc/functions.vim
@@ -68,7 +68,7 @@ syn keyword yagFunc deleteTrigger editMessageNoEscape contained
 syn keyword yagFunc getMessage pinMessage sendDM contained
 syn keyword yagFunc sendMessage sendMessageNoEscape contained
 syn keyword yagFunc sendMessageNoEscapeRetID sendMessageRetID contained
-syn keyword yagFunc unpinMessage contained
+syn keyword yagFunc unpinMessage publishMessage publishResponse contained
 
 " Misc
 syn keyword yagFunc adjective carg cembed createTicket contained


### PR DESCRIPTION
**Please describe the changes this pull request does and why it should be merged:**

See https://github.com/botlabs-gg/yagpdb/releases/tag/v2.29.0:

> publishMessage  and publishResponse has been added to custom command templates.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](../CONTRIBUTING.md)
