### PR TITLE
syntax: properly configure syntax regions

### DIFF
--- a/syntax/yagpdbcc.vim
+++ b/syntax/yagpdbcc.vim
@@ -31,7 +31,7 @@ syn case match
 
 " Define the region of the template expressions, where the real code is.
 syn region      yagExpr             start=#\v\{\{#ms=e+1 end=#\}\}#me=s-1
-    \ contains=ALLBUT,yagComment,yagEscape,yagFormat,yagTodo
+    \ contains=ALLBUT,yagComment,yagEscape,yagFormat,yagTodo keepend
 
 
 " Identifiers, i.e. $my_var, $myVar ($my-var is now allowed though).
@@ -42,7 +42,7 @@ hi def link     yagIdentifier       Identifier
 " Errors
 syn match       yagCharError        contained "\v'.{-}'"
 syn match       yagError            contained "\v>\$\w*"
-syn region      yagNestedBrace      contained start=#\v\{\{# end=#\v\}\}#
+syn region      yagNestedBrace      contained start=#\v\{\{# end=#\v\}\}# extend
 
 hi def link     yagCharError        yagError
 hi def link     yagNestedBrace      yagError
@@ -65,7 +65,7 @@ syn region      yagString           contained start=+"+
                                   \ skip=+\\\\\|\\"+ end=+"\|$+
                                   \ contains=@yagStringGroup,@Spell
 syn region      yagRawStr           contained start=#\v`# end=#\v`#
-                                  \ contains=yagFormat,@Spell fold
+                                  \ contains=yagFormat,@Spell fold extend
 
 hi def link     yagRawStr           yagString
 hi def link     yagString           String


### PR DESCRIPTION
**Please describe the changes this pull request does and why it should be merged:**

Specifically the `yagStr` region exhibits some odd behaviour (even more so in
conjunction with jo3-l/yag-template-lsp) in which a newline-terminated
double-quoted string extends its match region to EOF, when it should be EOL.

Fix this problem by setting the `keepend` attribute on `yagExpr`, which
disallows contained regions to go past their respective `end` pattern. This
fixes the funky behaviour of `yagStr`, whilst having its respective tests still
pass-

As a side-effect, we have to set `yagNestedBrace` to `extend`, such that the
second nested pair `}}` is highlighted as an error as well. For similar reasons,
we must do the same for `yagRawStr`, as it could theoretically contain legally
nested braces within the raw string, as exhibited by one of the test cases.
Without these secondary changes, tests are failing.

Signed-off-by: Luca Zeuch <l-zeuch@email.de>

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
