### PR TITLE
Actually highlight functions

### DIFF
--- a/scripts/gen_funcs.py
+++ b/scripts/gen_funcs.py
@@ -44,6 +44,7 @@ def main():
 
     funcs.sort()
     code = gen_code(funcs)
+    code += "\nhi def link yagFunc Function"
 
     outfile = 'syntax/yagpdbcc/functions.vim'
     write_file(code, outfile)

--- a/syntax/yagpdbcc/functions.vim
+++ b/syntax/yagpdbcc/functions.vim
@@ -261,3 +261,4 @@ syn keyword yagFunc urlunescape contained
 syn keyword yagFunc userArg contained
 syn keyword yagFunc verb contained
 syn keyword yagFunc weekNumber contained
+hi def link yagFunc Function


### PR DESCRIPTION
Until now, we apparently forgot to link the `yagFunc` syntax group to an actual highlight type. This adds such a link, to the `Function` highlight.

**Terms**
- [X] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [X] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
