### PR TITLE
syntax: support ydef file format

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,7 @@
 # Base
 /ftdetect/              @LRitzdorf
 /ftplugin/              @LRitzdorf
+/ftplugin/yagpdbdef.vim @l-zeuch
 /syntax/                @LRitzdorf
 /syntax/yagpdbdef.vim   @l-zeuch
 /autoload/              @l-zeuch

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,6 +6,7 @@
 /ftdetect/              @LRitzdorf
 /ftplugin/              @LRitzdorf
 /syntax/                @LRitzdorf
+/syntax/yagpdbdef.vim   @l-zeuch
 /autoload/              @l-zeuch
 /plugin/                @l-zeuch
 /indent/                @l-zeuch
@@ -15,5 +16,6 @@
 
 # Build and automation
 /test/                  @LRitzdorf
+/test/ydef.vim          @l-zeuch
 /.github/workflows/     @l-zeuch
 /Makefile               @l-zeuch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # 8.2.2434 is the current version on Debian Bullseye and its
-        # derivatives.
-        version: [v8.0.0000, v8.2.0000, v8.2.2434, v9.0.0000, stable]
+        version:
+          - v8.2.2434 # bullseye
+          - v9.0.1378 # bookworm
+          - v9.1.1230 # trixie
+          - v9.2.0524 # testing
+          - stable
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [v0.5.0, v0.6.0, v0.7.0, v0.8.0, v0.9.0, stable]
+        version: [v0.9.0, v0.10.0, v0.11.0, v0.12.0, stable]
 
     steps:
       - name: Checkout repository

--- a/ftdetect/yagpdbcc.vim
+++ b/ftdetect/yagpdbcc.vim
@@ -33,6 +33,10 @@ set cpoptions&vim
 au BufRead,BufNewFile   *.yag         setfiletype yagpdbcc
 au BufRead,BufNewFile   *.yagcc       setfiletype yagpdbcc
 
+" LSP syntax definitons.
+" See https://github.com/jo3-l/yag-template-lsp/tree/main/bundled-defs
+au BufRead,BufNewFile   *.ydef        setfiletype yagpdbdef
+
 " Also use *.tmpl, *.gotmpl et al., which are originally only Go, if configured.
 " Here, we need to explicitly override the default syntax - "setfiletype"
 " will not override an existing filetype.

--- a/syntax/yagpdbcc.vim
+++ b/syntax/yagpdbcc.vim
@@ -26,6 +26,12 @@ if exists('b:current_syntax')
 endif
 let b:current_syntax = 'yagpdbcc'
 
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
+runtime! syntax/yagpdbcc/functions.vim
+runtime! syntax/yagpdbcc/keywords.vim
+
 " Be case sensitive
 syn case match
 
@@ -117,3 +123,6 @@ syn match       yagObject           contained "\v%(>|[\$\)])@<!\.[[:alnum:]\_]+"
 hi def link     yagDot              yagType
 hi def link     yagObject           yagType
 hi def link     yagType             Type
+
+let &cpoptions = s:cpo_save
+unlet s:cpo_save

--- a/syntax/yagpdbdef.vim
+++ b/syntax/yagpdbdef.vim
@@ -1,0 +1,74 @@
+" yagpdb.vim: Vim syntax file for yagpdb custom commands.
+
+" Copyright (C) 2026    Lucas Ritzdorf, Luca Zeuch
+
+" This program is free software; you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation; either version 2 of the License, or
+" (at your option) any later version.
+
+" This program is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+
+" You should have received a copy of the GNU General Public License along
+" with this program; if not, write to the Free Software Foundation, Inc.,
+" 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+" Language: YAGPDB Custom Commands - Function Definitions
+" Maintainer: Luca Zeuch <l-zeuch@email.de>,
+"   LRitzdorf <42657792+LRitzdorf@users.noreply.github.com>
+
+if exists('b:current_syntax')
+    finish
+endif
+
+let s:cpo_save = &cpoptions
+set cpoptions&vim
+
+unlet! b:current_syntax
+syntax include @Yagpdbcc syntax/yagpdbcc.vim
+
+let b:current_syntax = 'yagpdbdef'
+
+syn case match
+
+
+" Markdown helper
+syn cluster   ydefInlineMarkdown   contains=markdownBold,
+                                          \ markdownItalic,
+                                          \ markdownCode,
+                                          \ markdownLink,
+                                          \ markdownUrl
+
+" Function definitions
+syn keyword   ydefDeclaration      func
+syn match     ydefParameter        "\v\w="
+syn match     ydefOperator         "\v\?|\.\.\."
+
+hi def link   ydefDeclaration      Keyword
+hi def link   ydefParameter        Identifier
+hi def link   ydefOperator         Operator
+
+syn keyword    ydefTodo             contained TODO FIXME XXX BUG HACK
+hi def link    ydefTodo             Todo
+
+" Function documentation
+syn region     ydefDocstring        start="\v^\t" end="$" extend
+                                  \ contains=@Spell,@ydefInlineMarkdown,
+                                           \ @ydefCommentGroup
+syn region     ydefCodeblock        matchgroup=markdownCodeDelimiter
+                                  \ start="^\s*`\{3}yag\>\s*$"
+                                  \ end="^\s*`\{3}\s*$" keepend
+                                  \ contains=@Yagpdbcc containedin=ydefDocstring
+
+" Comments
+syn cluster    ydefCommentGroup     contains=ydefTodo
+syn region     ydefComment          start="^==" end="$"
+                                  \ contains=@ydefCommentGroup,@Spell
+hi def link    ydefComment          Comment
+
+
+let &cpoptions = s:cpo_save
+unlet s:cpo_save

--- a/syntax/yagpdbdef.vim
+++ b/syntax/yagpdbdef.vim
@@ -1,6 +1,6 @@
 " yagpdb.vim: Vim syntax file for yagpdb custom commands.
 
-" Copyright (C) 2026    Lucas Ritzdorf, Luca Zeuch
+" Copyright (C) 2026    Luca Zeuch
 
 " This program is free software; you can redistribute it and/or modify
 " it under the terms of the GNU General Public License as published by

--- a/test/syntax/ydef.vader
+++ b/test/syntax/ydef.vader
@@ -1,0 +1,63 @@
+# Syntax tests: YAGPDB Custom Commands - Function Definitions
+
+# Copyright (C) 2026    Lucas Ritzdorf, Luca Zeuch
+
+# Available syntax functions are:
+#   SyntaxAt(): current cursor position
+#   SyntaxAt(col): current line at given column
+#   SyntaxAt(lnum, col): line and column
+#   SyntaxOf(pattern[, nth=1]): return syntax group name at first match
+
+# do not expand tabs -- ydef is a file format with significant whitespace.
+# vim: set noexpandtab:
+
+Before:
+  source ../syntax/yagpdbdef.vim
+
+After:
+  Restore
+
+Given (Function Definition):
+  func sendMessage channel= content= ?
+
+Execute (Test Function Keyword):
+  AssertEqual 'ydefDeclaration', SyntaxAt(1, 1), "Match func as declaration keyword"
+
+Execute (Test Function Parameters):
+  AssertEqual 'ydefParameter', SyntaxOf('channel='), "Match parameter assignments"
+  AssertEqual 'ydefParameter', SyntaxOf('content='), "Match parameter assignments"
+
+Execute (Test Function Operators):
+  AssertEqual 'ydefOperator', SyntaxOf('?'), "Match optional operator"
+
+
+Given (Comments):
+  == This is a section comment TODO
+
+Execute (Test Comment):
+  AssertEqual 'ydefComment', SyntaxAt(1, 1), "Match section comment"
+  AssertEqual 'ydefTodo', SyntaxOf('TODO'), "Match TODO marker"
+
+Given (Documentation);
+func foo
+	This is a documentation line.
+	TODO explain this later.
+
+Execute (Test Documentation):
+  AssertEqual 'ydefDocstring', SyntaxAt(2, 1), "Match documentation block"
+  AssertEqual 'ydefDocstring', SyntaxAt(3, 1), "Continue documentation block"
+  AssertEqual 'ydefTodo', SyntaxOf('TODO'), "Match TODO inside documentation"
+
+
+Given (Embedded YAGPDB Code Block);
+	Example:
+	```yag
+	{{ sendMessage nil "hello" }}
+	```
+
+Execute (Test Embedded Code Fence):
+  AssertEqual 'ydefDocstring', SyntaxAt(1, 1), "Docstring starts"
+  AssertEqual 'markdownCodeDelimiter', SyntaxOf('```yag'), "Match opening fence"
+  AssertEqual 'ydefCodeblock', SyntaxOf('{{'), "Load YAGPDB syntax inside fence"
+  AssertEqual 'yagFunc', SyntaxOf('sendMessage'), "Highlight embedded YAGPDB"
+  AssertEqual 'markdownCodeDelimiter', SyntaxOf('```', 2), "Match closing fence"

--- a/test/syntax/ydef.vader
+++ b/test/syntax/ydef.vader
@@ -1,6 +1,6 @@
 # Syntax tests: YAGPDB Custom Commands - Function Definitions
 
-# Copyright (C) 2026    Lucas Ritzdorf, Luca Zeuch
+# Copyright (C) 2026    Luca Zeuch
 
 # Available syntax functions are:
 #   SyntaxAt(): current cursor position


### PR DESCRIPTION
The yag-template-lsp project uses a custom file format to write definitions that the language server then uses to
1. find valid functions and
2. provide documentation.

Support this file format. See https://github.com/jo3-l/yag-template-lsp/tree/main/bundled-defs for examples and a syntax explainer.
As the documentation is written using Markdown, embed Markdown syntax as well as yagpdbcc syntax for use in Markdown codeblocks. Finally, add some tests.

Embedding yagpdbcc revealed an interesting problem: we never "fully" declared our syntax, in that yagpdbcc.vim depends on yagpdbcc/{functions,keywords}.vim. Declare that dependency via `runtime!`.

The plugin worked for normal custom commands because the Vim syntax engine traverses every `syntax/` directory in the runtimepath, matching files and directories to the given filetype, then just loading everything it could find. However, when trying to include a syntax definition (`syn include`), that full scan does not happen.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
