### PR TITLE
syntax/ydef: wip: markdown fixes

### DIFF
--- a/ftplugin/yagpdbdef.vim
+++ b/ftplugin/yagpdbdef.vim
@@ -1,0 +1,28 @@
+" Vim filetype plugin
+
+" Copyright (C) 2026   Luca Zeuch
+
+" This program is free software; you can redistribute it and/or modify
+" it under the terms of the GNU General Public License as published by
+" the Free Software Foundation; either version 2 of the License, or
+" (at your option) any later version.
+
+" This program is distributed in the hope that it will be useful,
+" but WITHOUT ANY WARRANTY; without even the implied warranty of
+" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+" GNU General Public License for more details.
+
+" You should have received a copy of the GNU General Public License along
+" with this program; if not, write to the Free Software Foundation, Inc.,
+" 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1
+
+let s_cpo_save = &cpoptions
+set cpoptions&vim
+
+" ydef files are tab-sensitive; do not expand tabs.
+setlocal noexpandtab

--- a/syntax/yagpdbdef.vim
+++ b/syntax/yagpdbdef.vim
@@ -28,6 +28,9 @@ let s:cpo_save = &cpoptions
 set cpoptions&vim
 
 unlet! b:current_syntax
+syntax include @Markdown syntax/markdown.vim
+
+unlet! b:current_syntax
 syntax include @Yagpdbcc syntax/yagpdbcc.vim
 
 let b:current_syntax = 'yagpdbdef'
@@ -35,12 +38,15 @@ let b:current_syntax = 'yagpdbdef'
 syn case match
 
 
-" Markdown helper
+" Markdown helpers
+syn region    ydefInlineCode       start="`" end="`" contained
 syn cluster   ydefInlineMarkdown   contains=markdownBold,
                                           \ markdownItalic,
-                                          \ markdownCode,
+                                          \ markdownBoldItalic,
+                                          \ markdownStrike,
                                           \ markdownLink,
-                                          \ markdownUrl
+                                          \ ydefInlineCode,
+hi def link   ydefInlineCode       markdownCode
 
 " Function definitions
 syn keyword   ydefDeclaration      func


### PR DESCRIPTION
This'll introduce fixes to the markdown highlighting embedded into ydef syntax.

Currently a WIP -- testing and feedback greatly appreciated.

**Terms**
- [x] I agree to follow this project's [Code of Conduct](CODE_OF_CONDUCT.md)
- [x] I have read and understood this project's [Contributing Guidelines](CONTRIBUTING.md)
